### PR TITLE
vir-148 디스커션 리스트 재작성

### DIFF
--- a/client/discussion/discussion_client.go
+++ b/client/discussion/discussion_client.go
@@ -2,12 +2,18 @@ package discussion
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strconv"
+	"time"
+
+	"code.gitea.io/gitea/services/context"
 
 	"code.gitea.io/gitea/client"
+	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/timeutil"
 	"github.com/go-resty/resty/v2"
 )
 
@@ -59,6 +65,45 @@ type ModifyDiscussionRequest struct {
 	Codes        []DiscussionCode `json:"codes"`
 }
 
+type DiscussionResponse struct {
+	Id         int64   `json:"id"`
+	Name       string  `json:"name"`
+	Content    string  `json:"content"`
+	RepoId     int64   `json:"repoId"`
+	PosterId   int64   `json:"posterId"`
+	CommitHash string  `json:"commitHash"`
+	IsClosed   bool    `json:"isClosed"`
+	Deadline   string  `json:"deadline"`
+	Assignees  []int64 `json:"assignees"`
+}
+
+type Discussion struct {
+	Id           int64                  `json:"id"`
+	Name         string                 `json:"name"`
+	Content      string                 `json:"content"`
+	RepoId       int64                  `json:"repoId"`
+	PosterId     int64                  `json:"posterId"`
+	CommitHash   string                 `json:"commitHash"`
+	Index        int64                  `json:"index"`
+	IsClosed     bool                   `json:"isClosed"`
+	CreatedUnix  timeutil.TimeStamp     `json:"createdUnix"` // required, but didn't exist before
+	ClosedUnix   timeutil.TimeStamp     `json:"closedUnix"`  // required, but didn't exist before
+	DeadlineUnix timeutil.TimeStamp     `json:"deadlineUnix"`
+	NumComments  int                    `json:"-"` // it can be computed
+	Repo         *repo_model.Repository `json:"-"` // it can be computed via d.LoadRepo()
+	Poster       *user_model.User       `json:"-"` // it can be computed via d.LoadPoster()
+}
+
+type DiscussionListResponse struct {
+	TotalCount  int64         `json:"totalCount"`
+	Discussions []*Discussion `json:"discussions"`
+}
+
+type DiscussionCountResponse struct {
+	OpenCount  int `json:"openCount"`
+	CloseCount int `json:"closeCount"`
+}
+
 func PostDiscussion(request *PostDiscussionRequest) (int, error) {
 	log.Info("PostDiscussion request : %v", request)
 	resp, err := client.Request().SetBody(request).Post("/discussion")
@@ -73,18 +118,43 @@ func PostDiscussion(request *PostDiscussionRequest) (int, error) {
 	return result, err
 }
 
-func GetDiscussionCount(repoId int64, isClosed bool) (*resty.Response, error) {
-	var isClosedAsInt = map[bool]int{false: 0, true: 1}[isClosed]
-	return client.Request().
-		SetQueryParam("isClosed", string(isClosedAsInt)).
-		Get(fmt.Sprintf("/discussion/%d/count", repoId))
+func GetDiscussion(repoId int64) (*DiscussionResponse, error) {
+	resp, err := client.Request().Get(fmt.Sprintf("/discussion/%d", repoId))
+	if err != nil {
+		return nil, err
+	}
+	var result = &DiscussionResponse{}
+	if err = json.Unmarshal(resp.Body(), &result); err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
-func GetDiscussionList(repoId int64, isClosed bool) (*resty.Response, error) {
-	var isClosedAsInt = map[bool]int{false: 0, true: 1}[isClosed]
-	return client.Request().
-		SetQueryParam("isClosed", string(isClosedAsInt)).
+func GetDiscussionCount(repoId int64) (*DiscussionCountResponse, error) {
+	resp, err := client.Request().Get(fmt.Sprintf("/discussion/%d/count", repoId))
+	if err != nil {
+		return nil, err
+	}
+	result := &DiscussionCountResponse{}
+	if err = json.Unmarshal(resp.Body(), result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func GetDiscussionList(repoId int64, isClosed bool, page int) (*DiscussionListResponse, error) {
+	isClosedAsString := strconv.FormatBool(isClosed)
+	pageAsString := strconv.Itoa(page)
+	resp, err := client.Request().
+		SetQueryParam("isClosed", isClosedAsString).
+		SetQueryParam("page", pageAsString).
 		Get(fmt.Sprintf("/discussion/%d/list", repoId))
+	if err != nil {
+		return nil, err
+	}
+	result := &DiscussionListResponse{}
+	json.Unmarshal(resp.Body(), result)
+	return result, nil
 }
 
 func HandleDiscussionAvailable() (*resty.Response, error) {
@@ -101,4 +171,53 @@ func PostComment(request *PostCommentRequest) (*resty.Response, error) {
 
 func ModifyDiscussion(request *ModifyDiscussionRequest) (*resty.Response, error) {
 	return client.Request().SetBody(request).Put("/discussion")
+}
+
+/**
+ * discussion methods
+ * the `discussion` struct could be moved to a separate file later
+ */
+func (d *Discussion) IsExpired() bool {
+	return d.DeadlineUnix < timeutil.TimeStamp(time.Now().Unix())
+}
+
+func (d *Discussion) GetLastEventTimestamp() timeutil.TimeStamp {
+	if d.IsClosed {
+		return d.ClosedUnix
+	}
+	return d.CreatedUnix
+}
+
+func (d *Discussion) GetLastEventLabel() string {
+	if d.IsClosed {
+		return "repo.discussion.closed_by"
+	}
+	return "repo.discussion.opened_by"
+}
+
+func (d *Discussion) GetLastEventLabelFake() string {
+	if d.IsClosed {
+		return "repo.discussion.closed_by_fake"
+	}
+	return "repo.discussion.opened_by_fake"
+}
+
+func (d *Discussion) LoadPoster(ctx *context.Context) (err error) {
+	if d.Poster == nil && d.PosterId != 0 {
+		d.Poster, err = user_model.GetPossibleUserByID(ctx, d.PosterId)
+		if err != nil {
+			d.PosterId = user_model.GhostUserID
+			d.Poster = user_model.NewGhostUser()
+			if !user_model.IsErrUserNotExist(err) {
+				return fmt.Errorf("getUserById.(poster) [%d]: %w", d.PosterId, err)
+			}
+			return nil
+		}
+	}
+	return err
+}
+
+func (d *Discussion) LoadRepo(ctx *context.Context) (err error) {
+	d.Repo = ctx.Repo.Repository
+	return nil
 }

--- a/options/locale/locale_ko-KR.ini
+++ b/options/locale/locale_ko-KR.ini
@@ -836,7 +836,9 @@ issues.review.reviewers=리뷰어
 issues.review.show_outdated=오래된 내역 보기
 issues.review.hide_outdated=오래된 내역 숨기기
 
-discussions.new=새로운 토론
+discussion.new=새로운 토론
+discussion.opened_by=<a href="%[2]s"> %[3]s</a>가 %[1]s을 오픈
+discussion.closed_by=<a href="%[2]s"> %[3]s</a>가 %[1]s을 닫음
 
 pulls.new=새 풀 리퀘스트
 pulls.compare_changes=새 풀 리퀘스트
@@ -861,6 +863,8 @@ pulls.invalid_merge_option=이 풀 리퀘스트에서 설정한 머지 옵션을
 
 
 
+activity.active_prs_count_1 = <strong>%d</strong> 개의 활성화된 풀 리퀘스트
+activity.active_prs_count_n = <strong>%d</strong> 개의 활성화된 풀 리퀘스트
 
 
 

--- a/routers/web/repo/discussion.go
+++ b/routers/web/repo/discussion.go
@@ -1,11 +1,14 @@
 package repo
 
 import (
+	"fmt"
 	"net/http"
+	"strconv"
 
 	discussion_client "code.gitea.io/gitea/client/discussion"
 	"code.gitea.io/gitea/modules/base"
 	"code.gitea.io/gitea/modules/log"
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/web"
 	"code.gitea.io/gitea/services/context"
 	discussion_service "code.gitea.io/gitea/services/discussion"
@@ -13,7 +16,9 @@ import (
 )
 
 const (
-	tplDiscussionNew base.TplName = "repo/discussion/new"
+	tplDiscussionNew  base.TplName = "repo/discussion/new"
+	tplDiscussions    base.TplName = "repo/discussion/list"
+	tplDiscussionView base.TplName = "repo/discussion/view"
 )
 
 func NewDiscussion(ctx *context.Context) {
@@ -50,4 +55,57 @@ func NewDiscussionPost(ctx *context.Context) {
 	ctx.JSON(http.StatusOK, map[string]interface{}{
 		"discussionId": discussionId,
 	})
+}
+
+// TODO: for now, some clumsy logics are included, but for later this function should be polished
+func Discussions(ctx *context.Context) {
+	// get discussion lists
+	listResp, err := discussion_service.GetDiscussionList(ctx)
+	if err != nil {
+		ctx.ServerError("Discussions", err)
+		return
+	}
+
+	// make paginator
+	currentPage, err := strconv.Atoi(ctx.FormString("page"))
+	if err != nil {
+		currentPage = 1
+	}
+	pager := context.NewPagination(int(listResp.TotalCount), setting.UI.IssuePagingNum, currentPage, 5)
+
+	// get count info
+	count, err := discussion_client.GetDiscussionCount(ctx.Repo.Repository.ID)
+	if err != nil {
+		ctx.ServerError("Discussions:GetDiscussionCount", err)
+	}
+
+	// get state info
+	isClosed := ctx.FormString("state") == "closed"
+	state := "open"
+	if isClosed {
+		state = "closed"
+	}
+
+	// prepare data for tamplete
+	ctx.Data["Title"] = ctx.Tr("repo.discussion.list")
+	ctx.Data["PageIsDiscussionList"] = true
+	ctx.Data["Discussions"] = listResp.Discussions
+	ctx.Data["RepoLink"] = ctx.Repo.RepoLink
+	ctx.Data["Page"] = pager
+	ctx.Data["OpenCount"] = count.OpenCount
+	ctx.Data["ClosedCount"] = count.CloseCount
+	ctx.Data["State"] = state
+	ctx.Data["AllStatesLink"] = fmt.Sprintf("%s/discussions?state=%s&page=1", ctx.Repo.RepoLink, state)
+	ctx.Data["OpenLink"] = fmt.Sprintf("%s/discussions?state=open&page=1", ctx.Repo.RepoLink)
+	ctx.Data["ClosedLink"] = fmt.Sprintf("%s/discussions?state=closed&page=1", ctx.Repo.RepoLink)
+
+	ctx.HTML(http.StatusOK, tplDiscussions)
+}
+
+func ViewDiscussion(ctx *context.Context) {
+	discussionId := ctx.ParamsInt64(":index")
+	discussionResponse, err := discussion_client.GetDiscussion(discussionId)
+	log.Info("discussion: %v, err: %v", discussionResponse, err)
+	ctx.Data["Discussion"] = discussionResponse
+	ctx.HTML(http.StatusOK, tplDiscussionView)
 }

--- a/routers/web/repo/issue.go
+++ b/routers/web/repo/issue.go
@@ -151,7 +151,7 @@ func MustAllowDiscussions(ctx *context.Context) {
 	}
 }
 
-func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption optional.Option[bool], isDiscussionOption optional.Option[bool]) {
+func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption optional.Option[bool]) {
 	var err error
 	viewType := ctx.FormString("type")
 	sortType := ctx.FormString("sort")
@@ -223,7 +223,6 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption opt
 		ReviewRequestedID: reviewRequestedID,
 		ReviewedID:        reviewedID,
 		IsPull:            isPullOption,
-		IsDiscussion:      isDiscussionOption,
 		IssueIDs:          nil,
 	}
 	if keyword != "" {
@@ -310,7 +309,6 @@ func issues(ctx *context.Context, milestoneID, projectID int64, isPullOption opt
 			ProjectID:         projectID,
 			IsClosed:          isShowClosed,
 			IsPull:            isPullOption,
-			IsDiscussion:      isDiscussionOption,
 			LabelIDs:          labelIDs,
 			SortType:          sortType,
 		})
@@ -520,8 +518,6 @@ func issueIDsFromSearch(ctx *context.Context, keyword string, opts *issues_model
 // Issues render issues page
 func Issues(ctx *context.Context) {
 	isPullList := ctx.Params(":type") == "pulls"
-	isDiscussion := ctx.Params(":type") == "discussions"
-
 	if isPullList {
 		// handle pull requests
 		MustAllowPulls(ctx)
@@ -530,14 +526,6 @@ func Issues(ctx *context.Context) {
 		}
 		ctx.Data["Title"] = ctx.Tr("repo.pulls")
 		ctx.Data["PageIsPullList"] = true
-	} else if isDiscussion {
-		// handle discussions
-		MustAllowDiscussions(ctx)
-		if ctx.Written() {
-			return
-		}
-		ctx.Data["Title"] = ctx.Tr("repo.discussions")
-		ctx.Data["PageIsDiscussionList"] = true
 	} else {
 		// handle issuses
 		MustEnableIssues(ctx)
@@ -549,7 +537,7 @@ func Issues(ctx *context.Context) {
 		ctx.Data["NewIssueChooseTemplate"] = issue_service.HasTemplatesOrContactLinks(ctx.Repo.Repository, ctx.Repo.GitRepo)
 	}
 
-	issues(ctx, ctx.FormInt64("milestone"), ctx.FormInt64("project"), optional.Some(isPullList), optional.Some(isDiscussion))
+	issues(ctx, ctx.FormInt64("milestone"), ctx.FormInt64("project"), optional.Some(isPullList))
 	if ctx.Written() {
 		return
 	}

--- a/routers/web/repo/milestone.go
+++ b/routers/web/repo/milestone.go
@@ -292,7 +292,7 @@ func MilestoneIssuesAndPulls(ctx *context.Context) {
 	ctx.Data["Title"] = milestone.Name
 	ctx.Data["Milestone"] = milestone
 
-	issues(ctx, milestoneID, projectID, optional.None[bool](), optional.None[bool]())
+	issues(ctx, milestoneID, projectID, optional.None[bool]())
 
 	ret := issue.ParseTemplatesFromDefaultBranch(ctx.Repo.Repository, ctx.Repo.GitRepo)
 	ctx.Data["NewIssueChooseTemplate"] = len(ret.IssueTemplates) > 0

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1184,7 +1184,7 @@ func registerRoutes(m *web.Route) {
 	// end "/{username}/{reponame}": view milestone, label, issue, pull, etc
 
 	m.Group("/{username}/{reponame}", func() {
-		m.Group("/{type:issues|pulls|discussions}", func() {
+		m.Group("/{type:issues|pulls}", func() {
 			m.Get("", repo.Issues)
 			m.Group("/{index}", func() {
 				m.Get("", repo.ViewIssue)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -1184,6 +1184,15 @@ func registerRoutes(m *web.Route) {
 	// end "/{username}/{reponame}": view milestone, label, issue, pull, etc
 
 	m.Group("/{username}/{reponame}", func() {
+		m.Group("/discussions", func() {
+			m.Get("", repo.Discussions)
+			m.Group("/{index}", func() {
+				m.Get("", repo.ViewDiscussion)
+			})
+		})
+	}, ignSignIn, context.RepoAssignment, context.RequireRepoReaderOr(unit.TypeIssues, unit.TypePullRequests, unit.TypeExternalTracker))
+
+	m.Group("/{username}/{reponame}", func() {
 		m.Group("/{type:issues|pulls}", func() {
 			m.Get("", repo.Issues)
 			m.Group("/{index}", func() {

--- a/services/discussion/discussion.go
+++ b/services/discussion/discussion.go
@@ -1,14 +1,16 @@
 package discussion
 
 import (
-	"context"
+	"strconv"
+
+	"code.gitea.io/gitea/services/context"
 
 	discussion_client "code.gitea.io/gitea/client/discussion"
 	repo_model "code.gitea.io/gitea/models/repo"
 	user_model "code.gitea.io/gitea/models/user"
 )
 
-func NewDiscussion(ctx context.Context, repo *repo_model.Repository, req *discussion_client.PostDiscussionRequest) (int, error) {
+func NewDiscussion(ctx *context.Context, repo *repo_model.Repository, req *discussion_client.PostDiscussionRequest) (int, error) {
 	// TODO: check poster permissions
 	if user_model.IsUserBlockedBy(ctx, req.Poster, repo.OwnerID) {
 		return -1, user_model.ErrBlockedUser
@@ -16,4 +18,26 @@ func NewDiscussion(ctx context.Context, repo *repo_model.Repository, req *discus
 	result, err := discussion_client.PostDiscussion(req)
 	// TODO: send notification
 	return result, err
+}
+
+func GetDiscussionList(ctx *context.Context) (*discussion_client.DiscussionListResponse, error) {
+	repo := ctx.Repo.Repository
+	repoId := repo.ID
+	isClosed := ctx.FormString("state") == "closed"
+	page, err := strconv.Atoi(ctx.FormString("page"))
+	if err != nil {
+		page = 1
+	}
+	page-- // gitea uses 1-based paginiation methodology, but discussion backend uses 0-based pagination methodology
+
+	discussionListResponse, err := discussion_client.GetDiscussionList(repoId, isClosed, page)
+	if err != nil {
+		return nil, err
+	}
+	// post process discussions
+	for _, d := range discussionListResponse.Discussions {
+		d.LoadRepo(ctx)
+		d.LoadPoster(ctx)
+	}
+	return discussionListResponse, nil
 }

--- a/templates/repo/discussion/discussionlist.tmpl
+++ b/templates/repo/discussion/discussionlist.tmpl
@@ -1,0 +1,66 @@
+<div id="issue-list" class="flex-list">
+	{{$approvalCounts := .ApprovalCounts}}
+	{{range .Discussions}}
+		<div class="flex-item">
+			<div class="flex-item-icon">
+				{{if $.CanWriteIssuesOrPulls}}
+				<input type="checkbox" autocomplete="off" class="issue-checkbox tw-mr-4" data-issue-id={{.ID}} aria-label="{{ctx.Locale.Tr "repo.issues.action_check"}} &quot;{{.Title}}&quot;">
+				{{end}}
+				{{template "repo/discussion/icon" .}}
+			</div>
+
+			<div class="flex-item-main">
+				<div class="flex-item-header">
+					<div class="flex-item-title">
+						<a class="tw-no-underline issue-title" href="{{$.RepoLink}}/discussions/{{.Id}}">{{RenderEmoji $.Context .Name | RenderCodeBlock}}</a>
+				
+						<span class="labels-list tw-ml-1">
+							<!-- labels here, but i removed that -->
+						</span>
+					</div>
+					{{if or .NumComments}}
+					<div class="flex-item-trailing">
+						{{if .NumComments}}
+						<div class="text grey">
+							<a class="tw-no-underline muted flex-text-block" href="{{$.RepoLink}}/discussions/{{.Id}}">
+								{{svg "octicon-comment" 16}}{{.NumComments}}
+							</a>
+						</div>
+						{{end}}
+					</div>
+					{{end}}
+				</div>
+				<div class="flex-item-body">
+					<a class="index" href="{{$.Link}}/{{.Id}}">
+						{{if eq $.listType "dashboard"}}
+							{{.Repo.FullName}}#{{.Index}}
+						{{else}}
+							#{{.Index}}
+						{{end}}
+					</a>
+					{{$timeStr := TimeSinceUnix .GetLastEventTimestamp ctx.Locale}}
+					{{if gt .Poster.ID 0}}
+						{{ctx.Locale.Tr .GetLastEventLabel $timeStr .Poster.HomeLink .Poster.GetDisplayName}}
+					{{else}}
+						{{ctx.Locale.Tr .GetLastEventLabelFake $timeStr .Poster.GetDisplayName}}
+					{{end}}
+
+					{{if ne .DeadlineUnix 0}}
+						<span class="due-date flex-text-inline" data-tooltip-content="{{ctx.Locale.Tr "repo.issues.due_date"}}">
+							<span{{if .IsOverdue}} class="text red"{{end}}>
+								{{svg "octicon-calendar" 14}}
+								{{DateTime "short" (.DeadlineUnix.FormatDate)}}
+							</span>
+						</span>
+					{{end}}
+				</div>
+			</div>
+		</div>
+	{{end}}
+	{{if .IssueIndexerUnavailable}}
+		<div class="ui error message">
+			<p>{{ctx.Locale.Tr "search.keyword_search_unavailable"}}</p>
+		</div>
+	{{end}}
+</div>
+{{template "base/paginate" .}}

--- a/templates/repo/discussion/icon.tmpl
+++ b/templates/repo/discussion/icon.tmpl
@@ -1,0 +1,5 @@
+{{if .IsClosed}}
+    {{svg "octicon-issue-closed" 16 "text red"}}
+{{else}}
+    {{svg "octicon-issue-opened" 16 "text green"}}
+{{end}}

--- a/templates/repo/discussion/icon.tmpl
+++ b/templates/repo/discussion/icon.tmpl
@@ -1,5 +1,5 @@
 {{if .IsClosed}}
-    {{svg "octicon-issue-closed" 16 "text red"}}
+    {{svg "octicon-discussion-closed" 16 "text red"}}
 {{else}}
-    {{svg "octicon-issue-opened" 16 "text green"}}
+    {{svg "octicon-comment-discussion" 16 "text green"}}
 {{end}}

--- a/templates/repo/discussion/list.tmpl
+++ b/templates/repo/discussion/list.tmpl
@@ -1,0 +1,54 @@
+{{template "base/head" .}}
+<div role="main" aria-label="{{.Title}}" class="page-content repository issue-list">
+	{{template "repo/header" .}}
+	<div class="ui container">
+	{{template "base/alert" .}}
+
+	{{if .PinnedIssues}}
+		<div id="issue-pins" {{if .IsRepoAdmin}}data-is-repo-admin{{end}}>
+			{{range .PinnedIssues}}
+				<div class="issue-card gt-word-break {{if $.IsRepoAdmin}}tw-cursor-grab{{end}}" data-move-url="{{$.Link}}/move_pin" data-issue-id="{{.ID}}">
+					{{template "repo/issue/card" (dict "Issue" . "Page" $ "isPinnedIssueCard" true)}}
+				</div>
+			{{end}}
+		</div>
+	{{end}}
+
+		<div class="list-header">
+			{{template "repo/issue/navbar" .}}
+			{{template "repo/issue/search" .}}
+			{{if not .Repository.IsArchived}}
+				<a class="ui small primary button new-discussion-button issue-list-new" 
+					href="{{.RepoLink}}/discussions/new">
+					{{ctx.Locale.Tr "repo.discussions.new"}}
+				</a>
+			{{else}}
+				{{if not .PageIsIssueList}}
+					<a class="ui small primary small button issue-list-new{{if not .PullRequestCtx.Allowed}} disabled{{end}}" href="{{if .PullRequestCtx.Allowed}}{{.PullRequestCtx.BaseRepo.Link}}/compare/{{.PullRequestCtx.BaseRepo.DefaultBranch | PathEscapeSegments}}...{{if ne .Repository.Owner.Name .PullRequestCtx.BaseRepo.Owner.Name}}{{PathEscape .Repository.Owner.Name}}:{{end}}{{.Repository.DefaultBranch | PathEscapeSegments}}{{end}}">{{ctx.Locale.Tr "action.compare_commits_general"}}</a>
+				{{end}}
+			{{end}}
+		</div>
+
+		{{template "repo/issue/filters" .}}
+
+		<div id="issue-actions" class="issue-list-toolbar tw-hidden">
+			<div class="issue-list-toolbar-left">
+				{{template "repo/issue/openclose" .}}
+				<!-- Total Tracked Time -->
+				{{if .TotalTrackedTime}}
+					<div class="ui compact tiny secondary menu">
+						<span class="item" data-tooltip-content='{{ctx.Locale.Tr "tracked_time_summary"}}'>
+							{{svg "octicon-clock"}}
+							{{.TotalTrackedTime | Sec2Time}}
+						</span>
+					</div>
+				{{end}}
+			</div>
+			<div class="issue-list-toolbar-right">
+				{{template "repo/issue/filter_actions" .}}
+			</div>
+		</div>
+		{{template "repo/discussion/discussionlist" dict "." . "listType" "repo"}}
+	</div>
+</div>
+{{template "base/footer" .}}


### PR DESCRIPTION
#30 에 대한 작업 사항입니다

### Main Features 
- 디스커션 목록 조회 
- 페이지네이션
- open/close 필터 


### 기타 변경 사항
- 기존의 issue/pulls 를 재활용하기엔 무리가 있다고 판단해, 템플릿 부분은 다시 작성하였습니다
- ko-KR 일부 항목 지역화 작업 진행 
- 디스커션 구조체의 일부 메서드 추가 $\rightarrow$ 디스커션 구조체가 비대해졌기에, 점차 분리가 필요할 듯해보입니다. 
- discussion 구조체 변경
  - 단순히 백엔드에서 받아온 정보만으론 go 템플릿 페이지 렌더링에 무리가 있어, 일부 필드에 한해 추가적 계산을 하는 부분을 추가하였습니다. 