### PR TITLE
구조체 인자 주입 방식의 DI에서 싱글톤 방식 DI로 변경

### DIFF
--- a/routers/api/v1/repo/ai_comment.go
+++ b/routers/api/v1/repo/ai_comment.go
@@ -36,14 +36,8 @@ func CreateAiPullComment(ctx *context.Context) {
 	// Check if attachments are enabled
 
 	form := web.GetForm(ctx).(*api.CreateAiPullCommentForm)
-
-	// TODOC 싱글톤으로 바꾼 뒤에
-	// TODOC 설정을 통해 의존성 주입하는 방식으로 바꾸기
-
-	aiService := new(ai_service.AiServiceImpl)
-	aiRequester := new(ai_service.AiRequesterImpl)
-	adapter := new(ai_service.DbAdapterImpl)
-	err := ai_service.AiService.CreateAiPullComment(aiService, ctx, form, aiRequester, adapter)
+	
+	err := ai_service.AiPullCommentService.CreateAiPullComment(ctx, form)
 
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, map[string]any{
@@ -83,13 +77,7 @@ func GenerateAiSampleCodes(ctx *context.Context) {
 
 	form := web.GetForm(ctx).(*api.GenerateAiSampleCodesForm)
 
-	// TODOC 싱글톤으로 바꾼 뒤에
-	// TODOC 설정을 통해 의존성 주입하는 방식으로 바꾸기
-
-	aiService := new(ai_service.DiscussionAiServiceImpl)
-	aiRequester := new(ai_service.AiSampleCodeRequesterImpl)
-	adapter := new(ai_service.AiSampleCodeDbAdapterImpl)
-	sampleCodes, err := ai_service.DiscussionAiService.GenerateAiSampleCodes(aiService, ctx, form, aiRequester, adapter)
+	sampleCodes, err := ai_service.AiSampleCodeService.GenerateAiSampleCodes(ctx, form)
 
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, map[string]any{
@@ -107,9 +95,7 @@ func CreateAiSampleCode(ctx *context.Context) {
 	// TODOC 공격 우려가 있어서 Create할 비대칭키 방식 암호화가 필요해보임.
 	form := web.GetForm(ctx).(*api.CreateAiSampleCodesForm)
 
-	aiService := new(ai_service.DiscussionAiServiceImpl)
-	adapter := new(ai_service.AiSampleCodeDbAdapterImpl)
-	sampleCode, err := ai_service.DiscussionAiService.CreateAiSampleCode(aiService, ctx, form, adapter)
+	sampleCode, err := ai_service.AiSampleCodeService.CreateAiSampleCode(ctx, form)
 
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, map[string]any{
@@ -125,10 +111,7 @@ func DeleteAiSampleCode(ctx *context.Context) {
 
 	form := web.GetForm(ctx).(*api.DeleteSampleCodesForm)
 
-	aiService := new(ai_service.DiscussionAiServiceImpl)
-	adapter := new(ai_service.AiSampleCodeDbAdapterImpl)
-
-	err := ai_service.DiscussionAiService.DeleteAiSampleCode(aiService, ctx, cast.ToInt64(form.TargetCommentId), adapter)
+	err := ai_service.AiSampleCodeService.DeleteAiSampleCode(ctx, cast.ToInt64(form.TargetCommentId))
 
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, map[string]any{
@@ -145,10 +128,7 @@ func GetAiSampleCode(ctx *context.Context) {
 
 	commentID := ctx.Req.URL.Query().Get("comment_id")
 
-	aiService := new(ai_service.DiscussionAiServiceImpl)
-	adapter := new(ai_service.AiSampleCodeDbAdapterImpl)
-
-	response, err := ai_service.DiscussionAiService.GetAiSampleCodeByCommentID(aiService, ctx, cast.ToInt64(commentID), adapter)
+	response, err := ai_service.AiSampleCodeService.GetAiSampleCodeByCommentID(ctx, cast.ToInt64(commentID))
 
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, map[string]any{

--- a/services/ai/adapter.go
+++ b/services/ai/adapter.go
@@ -7,18 +7,18 @@ import (
 	"github.com/spf13/cast"
 )
 
-type AiSampleCodeDbAdapter interface {
+type SampleCodeDbAdapter interface {
 	// GetDiscussionCommentByID(ctx *context.Context, id int64) (*issues_model.Issue, error)
-	InsertDiscussionAiSampleCode(ctx *context.Context, opts *discussion_model.CreateDiscussionAiCommentOpt) (*discussion_model.AiSampleCode, error)
-	DeleteDiscussionAiSampleCodeByID(ctx *context.Context, id int64) error
+	InsertAiSampleCode(ctx *context.Context, opts *discussion_model.CreateDiscussionAiCommentOpt) (*discussion_model.AiSampleCode, error)
+	DeleteAiSampleCodeByID(ctx *context.Context, id int64) error
 	GetAiSampleCodesByCommentID(ctx *context.Context, commentID int64) (*api.AiSampleCodeResponse, error)
 }
 
-type AiSampleCodeDbAdapterImpl struct{}
+type SampleCodeDbAdapterImpl struct{}
 
-var _ AiSampleCodeDbAdapter = &AiSampleCodeDbAdapterImpl{}
+var _ SampleCodeDbAdapter = &SampleCodeDbAdapterImpl{}
 
-func (is *AiSampleCodeDbAdapterImpl) GetAiSampleCodesByCommentID(ctx *context.Context, commentID int64) (*api.AiSampleCodeResponse, error) {
+func (is *SampleCodeDbAdapterImpl) GetAiSampleCodesByCommentID(ctx *context.Context, commentID int64) (*api.AiSampleCodeResponse, error) {
 
 	sampleCodes, err := discussion_model.GetAiSampleCodeByCommentID(ctx, commentID)
 
@@ -41,11 +41,11 @@ func (is *AiSampleCodeDbAdapterImpl) GetAiSampleCodesByCommentID(ctx *context.Co
 	return &response, nil
 }
 
-func (is *AiSampleCodeDbAdapterImpl) InsertDiscussionAiSampleCode(ctx *context.Context, opts *discussion_model.CreateDiscussionAiCommentOpt) (*discussion_model.AiSampleCode, error) {
+func (is *SampleCodeDbAdapterImpl) InsertAiSampleCode(ctx *context.Context, opts *discussion_model.CreateDiscussionAiCommentOpt) (*discussion_model.AiSampleCode, error) {
 	return discussion_model.CreateAiSampleCode(ctx, opts)
 }
 
-func (is *AiSampleCodeDbAdapterImpl) DeleteDiscussionAiSampleCodeByID(ctx *context.Context, id int64) error {
+func (is *SampleCodeDbAdapterImpl) DeleteAiSampleCodeByID(ctx *context.Context, id int64) error {
 
 	return discussion_model.DeleteAiSampleCodeByID(ctx, id)
 

--- a/services/ai/base.go
+++ b/services/ai/base.go
@@ -1,0 +1,19 @@
+package ai
+
+var (
+	AiPullCommentService   PullCommentService
+	AiPullCommentDbAdapter PullCommentDbAdapter
+	AiPullCommentRequester PullCommentRequester
+	AiSampleCodeService    SampleCodeService
+	AiSampleCodeDbAdapter  SampleCodeDbAdapter
+	AiSampleCodeRequester  SampleCodeRequester
+)
+
+func init() {
+	AiPullCommentService = new(PullCommentServiceImpl)
+	AiSampleCodeService = new(SampleCodeServiceImpl)
+	AiSampleCodeDbAdapter = new(SampleCodeDbAdapterImpl)
+	AiPullCommentDbAdapter = new(PullCommentDbAdapterImpl)
+	AiPullCommentRequester = new(PullCommentRequesterImpl)
+	AiSampleCodeRequester = new(SampleCodeRequesterImpl)
+}

--- a/services/ai/pull_comment.go
+++ b/services/ai/pull_comment.go
@@ -10,25 +10,27 @@ import (
 	"code.gitea.io/gitea/services/context"
 )
 
-type AiService interface {
-	CreateAiPullComment(ctx *context.Context, form *api.CreateAiPullCommentForm, aiRequester AiRequester, adapter DbAdapter) error
-	DeleteAiPullComment(ctx *context.Context, id int64, adapter DbAdapter) error
+type PullCommentService interface {
+	CreateAiPullComment(ctx *context.Context, form *api.CreateAiPullCommentForm) error
+	DeleteAiPullComment(ctx *context.Context, id int64) error
 }
 
+var _ PullCommentService = &PullCommentServiceImpl{}
+
 // TODOC 잘못된 형식의 json이 돌아올 때 예외 반환하기(json 형식 표시하도록)
-func (aiController *AiServiceImpl) CreateAiPullComment(ctx *context.Context, form *api.CreateAiPullCommentForm, aiRequester AiRequester, adapter DbAdapter) error {
+func (is *PullCommentServiceImpl) CreateAiPullComment(ctx *context.Context, form *api.CreateAiPullCommentForm) error {
 	branch := form.Branch
-	var wg *sync.WaitGroup = new(sync.WaitGroup)
+	wg := new(sync.WaitGroup)
 
 	requestCnt := len(*form.FileContents)
 	wg.Add(requestCnt)
 
-	resultQueue := make(chan *AiReviewResponse, requestCnt)
+	resultQueue := make(chan *AiPullCommentResponse, requestCnt)
 
 	for _, fileContent := range *form.FileContents {
 		go func(fileContent *api.PathContentMap) {
 			defer wg.Done()
-			result, err := aiRequester.RequestReviewToAI(ctx, &AiReviewRequest{
+			result, err := AiPullCommentRequester.RequestReviewToAI(ctx, &AiPullCommentRequest{
 				Branch:   branch,
 				TreePath: fileContent.TreePath,
 				Content:  fileContent.Content,
@@ -50,22 +52,22 @@ func (aiController *AiServiceImpl) CreateAiPullComment(ctx *context.Context, for
 		return fmt.Errorf("pullID is invalid")
 	}
 
-	return saveResults(ctx, resultQueue, pullID, adapter)
+	return saveResults(ctx, resultQueue, pullID)
 }
 
-func (aiService *AiServiceImpl) DeleteAiPullComment(ctx *context.Context, id int64, adapter DbAdapter) error {
+func (is *PullCommentServiceImpl) DeleteAiPullComment(ctx *context.Context, id int64) error {
 
-	return adapter.DeleteAiPullCommentByID(ctx, id)
+	return AiPullCommentDbAdapter.DeleteAiPullCommentByID(ctx, id)
 }
 
-func saveResults(ctx *context.Context, reviewResults chan *AiReviewResponse, pullID int64, adapter DbAdapter) error {
-	pull, err := adapter.GetIssueByID(ctx, pullID)
+func saveResults(ctx *context.Context, reviewResults chan *AiPullCommentResponse, pullID int64) error {
+	pull, err := AiPullCommentDbAdapter.GetIssueByID(ctx, pullID)
 	if err != nil {
 		return fmt.Errorf("pr not found by id")
 	}
 
 	for result := range reviewResults {
-		_, err := adapter.CreateAiPullComment(ctx, &issues_model.CreateAiPullCommentOption{
+		_, err := AiPullCommentDbAdapter.CreateAiPullComment(ctx, &issues_model.CreateAiPullCommentOption{
 			Doer:     ctx.Doer,
 			Repo:     pull.Repo,
 			Pull:     pull,
@@ -80,23 +82,23 @@ func saveResults(ctx *context.Context, reviewResults chan *AiReviewResponse, pul
 	return nil
 }
 
-type DbAdapter interface {
+type PullCommentDbAdapter interface {
 	GetIssueByID(ctx *context.Context, id int64) (*issues_model.Issue, error)
 	CreateAiPullComment(ctx *context.Context, opts *issues_model.CreateAiPullCommentOption) (*issues_model.AiPullComment, error)
 	DeleteAiPullCommentByID(ctx *context.Context, id int64) error
 }
 
-type DbAdapterImpl struct{}
+type PullCommentDbAdapterImpl struct{}
 
-func (is *DbAdapterImpl) GetIssueByID(ctx *context.Context, id int64) (*issues_model.Issue, error) {
+func (is *PullCommentDbAdapterImpl) GetIssueByID(ctx *context.Context, id int64) (*issues_model.Issue, error) {
 	return issues_model.GetIssueByID(ctx, id)
 }
 
-func (is *DbAdapterImpl) CreateAiPullComment(ctx *context.Context, opts *issues_model.CreateAiPullCommentOption) (*issues_model.AiPullComment, error) {
+func (is *PullCommentDbAdapterImpl) CreateAiPullComment(ctx *context.Context, opts *issues_model.CreateAiPullCommentOption) (*issues_model.AiPullComment, error) {
 	return issues_model.CreateAiPullComment(ctx, opts)
 }
 
-func (is *DbAdapterImpl) DeleteAiPullCommentByID(ctx *context.Context, id int64) error {
+func (is *PullCommentDbAdapterImpl) DeleteAiPullCommentByID(ctx *context.Context, id int64) error {
 
 	return issues_model.DeleteAiPullCommentByID(ctx, id)
 

--- a/services/ai/requester.go
+++ b/services/ai/requester.go
@@ -18,19 +18,19 @@ type AiSampleCodeResponse struct {
 	SampleCode string `json:"sample_code"`
 }
 
-type AiSampleCodeRequesterImpl struct{}
+type SampleCodeRequesterImpl struct{}
 
-type AiSampleCodeRequester interface {
+type SampleCodeRequester interface {
 	RequestReviewToAI(ctx *context.Context, request *AiSampleCodeRequest) (*AiSampleCodeResponse, error)
 }
 
-var _ AiSampleCodeRequester = &AiSampleCodeRequesterImpl{}
+var _ SampleCodeRequester = &SampleCodeRequesterImpl{}
 
 type AiSampleCodeResult struct {
 	SampleCode string `json:"sample_code"`
 }
 
-func (aiRequest *AiSampleCodeRequesterImpl) RequestReviewToAI(ctx *context.Context, request *AiSampleCodeRequest) (*AiSampleCodeResponse, error) {
+func (aiRequest *SampleCodeRequesterImpl) RequestReviewToAI(ctx *context.Context, request *AiSampleCodeRequest) (*AiSampleCodeResponse, error) {
 
 	response, err := ai_client.Request().SetBody(request).Post("/api/sample")
 
@@ -50,37 +50,36 @@ func (aiRequest *AiSampleCodeRequesterImpl) RequestReviewToAI(ctx *context.Conte
 	return result, nil
 }
 
-type AiReviewRequest struct {
+type AiPullCommentRequest struct {
 	Branch   string `json:"branch"`
 	TreePath string `json:"file_path"`
 	Content  string `json:"code"`
 }
 
-type AiReviewResponse struct {
+type AiPullCommentResponse struct {
 	Branch   string `json:"branch"`
 	TreePath string `json:"file_path"`
 	Content  string `json:"code"`
 }
 
-type AiServiceImpl struct{}
+type PullCommentServiceImpl struct{}
 
-type AiRequesterImpl struct{}
+type PullCommentRequesterImpl struct{}
 
-type AiRequester interface {
-	RequestReviewToAI(ctx *context.Context, request *AiReviewRequest) (*AiReviewResponse, error)
+type PullCommentRequester interface {
+	RequestReviewToAI(ctx *context.Context, request *AiPullCommentRequest) (*AiPullCommentResponse, error)
 }
 
-var _ AiService = &AiServiceImpl{}
-var _ AiRequester = &AiRequesterImpl{}
+var _ PullCommentRequester = &PullCommentRequesterImpl{}
 
-func (aiRequest *AiRequesterImpl) RequestReviewToAI(ctx *context.Context, request *AiReviewRequest) (*AiReviewResponse, error) {
+func (aiRequest *PullCommentRequesterImpl) RequestReviewToAI(ctx *context.Context, request *AiPullCommentRequest) (*AiPullCommentResponse, error) {
 
 	response, err := ai_client.Request().SetBody(request).Post(fmt.Sprintf("/api/sample"))
 
 	if err != nil {
 		return nil, err
 	}
-	result := &AiReviewResponse{}
+	result := &AiPullCommentResponse{}
 
 	json.Unmarshal(response.Body(), result)
 


### PR DESCRIPTION
한 일
---
- 싱글톤 방식의 DI로 변경
- 샘플코드 기능이 범용적으로 쓰이는 것을 고려하여 관련 구조체를 AiSampleCode~로 바꾸고 메소드에서 Discussion이란 이름을 배제함
