### PR TITLE
Fix/vir-152 goroutine too slow 

### DIFF
--- a/services/ai/pull_comment.go
+++ b/services/ai/pull_comment.go
@@ -63,7 +63,8 @@ func (is *PullCommentServiceImpl) DeleteAiPullComment(ctx *context.Context, id i
 func saveResults(ctx *context.Context, reviewResults chan *AiPullCommentResponse, pullID int64) error {
 	pull, err := AiPullCommentDbAdapter.GetIssueByID(ctx, pullID)
 	if err != nil {
-		return fmt.Errorf("pr not found by id")
+		// context canceled
+		return fmt.Errorf("pr not found by id %v", err)
 	}
 
 	for result := range reviewResults {

--- a/services/context/context.go
+++ b/services/context/context.go
@@ -96,6 +96,11 @@ func GetValidateContext(req *http.Request) (ctx *ValidateContext) {
 	return ctx
 }
 
+func (c Context) NewChildContext() *Context {
+	c.Base.originCtx = context.WithoutCancel(c.Base.originCtx)
+	return &c
+}
+
 func NewTemplateContextForWeb(ctx *Context) TemplateContext {
 	tmplCtx := NewTemplateContext(ctx)
 	tmplCtx["Locale"] = ctx.Base.Locale


### PR DESCRIPTION
root cause: 
pull_comment.go:saveResults:L64~

-> ctx is canceled

solution:
create clone context method in Context structure 

```go
func (c Context) NewChildContext() *Context {
	c.Base.originCtx = context.WithoutCancel(c.Base.originCtx)
	return &c
}
```
