### PR TITLE
feat: discussion file 상세 뷰 하이라이트 추가:

### DIFF
--- a/routers/web/repo/discussion.go
+++ b/routers/web/repo/discussion.go
@@ -284,7 +284,6 @@ func RenderNewDiscussionComment(ctx *context.Context) {
 	comments = append(comments, newComment)
 	ctx.Data["comments"] = comments
 
-	// TODO: 디스커션 코멘트 렌더링 하기
 
 	ctx.HTML(http.StatusOK, tplDiscussionFileComments)
 
@@ -313,7 +312,7 @@ func DiscussionContent(ctx *context.Context) {
 
 	discussionId := ctx.ParamsInt64(":index")
 
-	discussionContent, err := discussion_service.GetDiscussionContent(ctx, discussionId)
+	discussionContent, err := discussion_service.GetDiscussionContentWithHighlights(discussionId)
 
 	if err != nil {
 		ctx.JSONError(err.Error())

--- a/routers/web/repo/highlight_download.go
+++ b/routers/web/repo/highlight_download.go
@@ -1,11 +1,10 @@
 package repo
 
 import (
+	"html/template"
 	"io"
 	"net/http"
 	"unicode/utf8"
-
-	"html/template"
 
 	"code.gitea.io/gitea/modules/highlight"
 	"code.gitea.io/gitea/modules/log"

--- a/services/discussion/discussion.go
+++ b/services/discussion/discussion.go
@@ -1,7 +1,10 @@
 package discussion
 
 import (
+	"fmt"
 	"strconv"
+
+	"code.gitea.io/gitea/modules/highlight"
 
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/services/context"
@@ -45,16 +48,55 @@ func GetDiscussionList(ctx *context.Context) (*discussion_client.DiscussionListR
 	return discussionListResponse, nil
 }
 
-func GetDiscussionContent(ctx *context.Context, discussionId int64) (*discussion_client.DiscussionContentResponse, error) {
-
-	content, err := discussion_client.GetDiscussionContent(discussionId)
-
+func GetDiscussionContent(discussionID int64) (*discussion_client.DiscussionContentResponse, error) {
+	contents, err := discussion_client.GetDiscussionContents(discussionID)
 	if err != nil {
-		log.Error("discussion_client.GetDiscussionContent failed: %v", err.Error())
 		return nil, err
 	}
 
-	return content, nil
+	return contents, nil
+}
+
+func GetDiscussionContentWithHighlights(discussionID int64) (*discussion_client.DiscussionContentResponse, error) {
+	contents, err := discussion_client.GetDiscussionContents(discussionID)
+	if err != nil {
+		return nil, err
+	}
+
+	err = highlightContents(contents)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return contents, nil
+
+}
+
+func highlightContents(contents *discussion_client.DiscussionContentResponse) error {
+	for i := range contents.Contents {
+		if err := highlightContent(&contents.Contents[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func highlightContent(content *discussion_client.FileContent) error {
+	for i, block := range content.CodeBlocks {
+		for j, line := range block.Lines {
+			html, _, err := highlight.File(content.FilePath, "", []byte(line.Content))
+			if err != nil {
+				return fmt.Errorf("failed to highlight line %d in block %d: %w", j, i, err)
+			}
+			if len(html) == 0 {
+				continue
+			}
+
+			content.CodeBlocks[i].Lines[j].Content = string(html[0])
+		}
+	}
+	return nil
 }
 
 func DeleteDiscussionComment(ctx *context.Context, discussionId int64, posterId int64) error {

--- a/web_src/js/components/DiscussionFileCodeLine.vue
+++ b/web_src/js/components/DiscussionFileCodeLine.vue
@@ -17,8 +17,7 @@
         <SvgIcon name="octicon-plus" />
       </button>
     </td>
-    <td class="lines-code chroma">
-      {{ line.content }}
+    <td class="lines-code chroma"  style="white-space: pre-wrap;" v-html="line.content">
     </td>
   </tr>
 </template>


### PR DESCRIPTION
한일
---
디스커션 상세 뷰에서 하이라이트 추가


추가로 고려해야 할 부분
---
현재 discussion 파일 코드의 라인을 나눠서 가져오는 부분만이 구현된 상태인데 줄 별로 하이라이트를 따로 때리는 건 성능 상의 문제가 있을 수 있고 코드 가독성도 안좋기 때문에 a라인에서 b라인 까지의 내용을 줄 별로 나누지 않고 가져오는 api를 추가할지 고려해봐야 할듯.