### PR TITLE
[VIR-191] remove unnecessary git services for migration

### DIFF
--- a/modules/structs/repo.go
+++ b/modules/structs/repo.go
@@ -376,11 +376,6 @@ func (gt GitServiceType) TokenAuth() bool {
 var SupportedFullGitService = []GitServiceType{
 	GithubService,
 	GitlabService,
-	GiteaService,
-	GogsService,
-	OneDevService,
-	GitBucketService,
-	CodebaseService,
 }
 
 // RepoTransfer represents a pending repo transfer

--- a/routers/web/repo/migrate.go
+++ b/routers/web/repo/migrate.go
@@ -254,8 +254,10 @@ func setMigrationContextData(ctx *context.Context, serviceType structs.GitServic
 	ctx.Data["IsForcedPrivate"] = setting.Repository.ForcePrivate
 	ctx.Data["DisableNewPullMirrors"] = setting.Mirror.DisableNewPull
 
-	// Plain git should be first
-	ctx.Data["Services"] = append([]structs.GitServiceType{structs.PlainGitService}, structs.SupportedFullGitService...)
+	gitServices := make([]structs.GitServiceType, 0)
+	gitServices = append(gitServices, structs.SupportedFullGitService...)
+	gitServices = append(gitServices, structs.PlainGitService)
+	ctx.Data["Services"] = gitServices
 	ctx.Data["service"] = serviceType
 }
 


### PR DESCRIPTION
close #77 
<img width="1269" alt="image" src="https://github.com/user-attachments/assets/0d135a37-76a5-4133-b8d2-825741f49284">

일반 Git, Github, Gitlab 을 제외하고는 모두 제거하였습니다