### PR TITLE
[VIR-208] 디스커션 생성 알림 기능 

### DIFF
--- a/client/discussion/discussion_client.go
+++ b/client/discussion/discussion_client.go
@@ -4,241 +4,27 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"time"
-
-	"code.gitea.io/gitea/services/context"
 
 	"code.gitea.io/gitea/client"
-	repo_model "code.gitea.io/gitea/models/repo"
-	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/client/discussion/model"
 	"code.gitea.io/gitea/modules/log"
-	"code.gitea.io/gitea/modules/timeutil"
 	"github.com/go-resty/resty/v2"
 )
 
-type DiscussionCode struct {
-	Id        int64  `json:"id"`
-	FilePath  string `json:"filePath"`
-	StartLine int    `json:"startLine"`
-	EndLine   int    `json:"endLine"`
-}
-
-type DeleteDiscussionCommentRequest struct {
-	PosterId            int64 `json:"posterId"`
-	DiscussionCommentId int64 `json:"discussionCommentId"`
-}
-
-type PostDiscussionRequest struct {
-	RepoId     int64            `json:"repoId"`
-	Poster     *user_model.User `json:"-"`
-	PosterId   int64            `json:"posterId"`
-	Name       string           `json:"name"`
-	Content    string           `json:"content"`
-	BranchName string           `json:"branchName"`
-	Codes      []DiscussionCode `json:"codes"`
-}
-
-type DiscussionAvailableRequest struct {
-	RepoId    int64 `json:"repoId"`
-	Available bool  `json:"available"`
-}
-
-type CommentScopeEnum int
-
-const (
-	CommentScopeGlobal CommentScopeEnum = iota
-	CommentScopeLocal
-)
-
-type PostCommentRequest struct {
-	DiscussionId int64            `json:"discussionId"`
-	CodeId       *int64           `json:"codeId"`
-	GroupId      *int64           `json:"groupId"`
-	PosterId     int64            `json:"posterId"`
-	Scope        CommentScopeEnum `json:"scope"`
-	StartLine    *int32           `json:"startLine"`
-	EndLine      *int32           `json:"endLine"`
-	Content      string           `json:"content"`
-}
-
-type ModifyDiscussionRequest struct {
-	RepoId       int64            `json:"repoId"`
-	DiscussionId int64            `json:"discussionId"`
-	PosterId     int64            `json:"posterId"`
-	Name         string           `json:"name"`
-	Content      string           `json:"content"`
-	Codes        []DiscussionCode `json:"codes"`
-}
-
-type DiscussionResponse struct {
-	Id          int64              `json:"id"`
-	Name        string             `json:"name"`
-	Content     string             `json:"content"`
-	RepoId      int64              `json:"repoId"`
-	PosterId    int64              `json:"posterId"`
-	CommitHash  string             `json:"commitHash"`
-	IsClosed    bool               `json:"isClosed"`
-	Deadline    timeutil.TimeStamp `json:"deadline"`
-	Assignees   []int64            `json:"assignees"`
-	CreatedUnix timeutil.TimeStamp `json:"createdUnix"`
-	UpdatedUnix timeutil.TimeStamp `json:"updatedUnix"`
-	Index       int64              `json:"index"`
-	Poster      *user_model.User   `json:"-"`
-}
-
-type ReactionList []*DiscussionReaction
-
-func (list ReactionList) GroupByType() map[string]ReactionList {
-	reactions := make(map[string]ReactionList)
-	for _, reaction := range list {
-		reactions[reaction.Type] = append(reactions[reaction.Type], reaction)
-	}
-	return reactions
-}
-
-func (list ReactionList) HasUser(userId int64) bool {
-	if userId == 0 {
-		return false
-	}
-	for _, reaction := range list {
-		if reaction.UserId == userId {
-			return true
-		}
-	}
-	return false
-}
-
-type Discussion struct {
-	Id           int64                  `json:"id"`
-	Name         string                 `json:"name"`
-	Content      string                 `json:"content"`
-	RepoId       int64                  `json:"repoId"`
-	PosterId     int64                  `json:"posterId"`
-	CommitHash   string                 `json:"commitHash"`
-	Index        int64                  `json:"index"`
-	IsClosed     bool                   `json:"isClosed"`
-	CreatedUnix  timeutil.TimeStamp     `json:"createdUnix"` // required, but didn't exist before
-	ClosedUnix   timeutil.TimeStamp     `json:"closedUnix"`  // required, but didn't exist before
-	DeadlineUnix timeutil.TimeStamp     `json:"deadlineUnix"`
-	NumComments  int                    `json:"-"` // it can be computed
-	Repo         *repo_model.Repository `json:"-"` // it can be computed via d.LoadRepo()
-	Poster       *user_model.User       `json:"-"` // it can be computed via d.LoadPoster()
-}
-
-type DiscussionListResponse struct {
-	TotalCount  int64         `json:"totalCount"`
-	Discussions []*Discussion `json:"discussions"`
-}
-
-type ModifyDiscussionCommentRequest struct {
-	DiscussionId        int64            `json:"discussionId"`
-	DiscussionCommentId int64            `json:"discussionCommentId"`
-	CodeId              *int64           `json:"codeId"`
-	PosterId            int64            `json:"posterId"`
-	Scope               CommentScopeEnum `json:"scope"`
-	StartLine           *int32           `json:"startLine"`
-	EndLine             *int32           `json:"endLine"`
-	Content             string           `json:"content"`
-}
-
-type DiscussionCountResponse struct {
-	OpenCount  int `json:"openCount"`
-	CloseCount int `json:"closeCount"`
-}
-
-type ExtractedLine struct {
-	LineNumber int    `json:"lineNumber"`
-	Content    string `json:"content"`
-}
-type CodeBlock struct {
-	CodeId   int64                       `json:"codeId"`
-	Lines    []ExtractedLine             `json:"lines"`
-	Comments []DiscussionCommentResponse `json:"comments"`
-}
-type FileContent struct {
-	FilePath   string      `json:"filePath"`
-	CodeBlocks []CodeBlock `json:"codeBlocks"`
-}
-
-type DiscussionCommentResponse struct {
-	Id           int64                 `json:"id"`
-	FilePath     string                `json:"filePath"`
-	GroupId      int64                 `json:"groupId"`
-	DiscussionId int64                 `json:"discussionId"`
-	PosterId     int64                 `json:"posterId"`
-	CodeId       int64                 `json:"codeId"`
-	Scope        string                `json:"scope"`
-	StartLine    int64                 `json:"startLine"`
-	EndLine      int64                 `json:"endLine"`
-	Content      string                `json:"content"`
-	CreatedUnix  timeutil.TimeStamp    `json:"createdUnix"`
-	Reactions    []*DiscussionReaction `json:"reactions"`
-}
-
-type ReactionTypeEnum = string
-
-const (
-	PLUS_ONE  ReactionTypeEnum = "+1"
-	MINUS_ONE ReactionTypeEnum = "-1"
-	LAUGH     ReactionTypeEnum = "laugh"
-	HOORAY    ReactionTypeEnum = "hooray"
-	CONFUSED  ReactionTypeEnum = "confused"
-	HEART     ReactionTypeEnum = "heart"
-	ROCKET    ReactionTypeEnum = "rocket"
-	EYES      ReactionTypeEnum = "eyes"
-)
-
-type DiscussionReaction struct {
-	Id           int64            `json:"id"`
-	Type         ReactionTypeEnum `json:"type"`
-	DiscussionId int64            `json:"discussionId"`
-	CommentId    int64            `json:"commentId"`
-	UserId       int64            `json:"userId"`
-}
-type DiscussionContentResponse struct {
-	DiscussionId    int64                       `json:"discussionId"`
-	Contents        []FileContent               `json:"contents"`
-	GlobalComments  []DiscussionCommentResponse `json:"globalComments"`
-	GlobalReactions []DiscussionReaction        `json:"discussionReaction"`
-}
-
-type DiscussionDeadline struct {
-	Deadline *time.Time `json:"due_date"`
-}
-
-type UpdateAssigneeRequest struct {
-	DiscussionId int64 `json:"discussionId"`
-	AssigneeId   int64 `json:"assigneeId"`
-}
-
-type DiscussionErrorResponse struct {
-	TimeStamp timeutil.TimeStamp `json:"timestamp"`
-	Status    int                `json:"status"`
-	Error     string             `json:"error"`
-	message   string
-}
-
 func validateResponse(resp *resty.Response) error {
 	if resp.IsError() {
-		var errResp DiscussionErrorResponse
+		var errResp model.DiscussionErrorResponse
 		if err := json.Unmarshal(resp.Body(), &errResp); err != nil {
 			log.Error("Failed to parse error response: %v", err)
 			return fmt.Errorf("unexpected error: %s", resp.Status())
 		}
-		log.Error("API Error %d: %s", errResp.Status, errResp.message)
-		return fmt.Errorf("api error %d: %s", errResp.Status, errResp.message)
+		log.Error("API Error %d: %s", errResp.Status, errResp.Message)
+		return fmt.Errorf("api error %d: %s", errResp.Status, errResp.Message)
 	}
 	return nil
 }
 
-type DiscussionReactionRequest struct {
-	Type         ReactionTypeEnum `json:"type"`
-	DiscussionId int64            `json:"discussionId"`
-	CommentId    int64            `json:"commentId"`
-	UserId       int64            `json:"userId"`
-}
-
-func PostDiscussion(request *PostDiscussionRequest) (int, error) {
+func PostDiscussion(request *model.PostDiscussionRequest) (int, error) {
 	resp, err := client.Request().
 		SetBody(request).
 		Post("/discussion")
@@ -258,7 +44,7 @@ func PostDiscussion(request *PostDiscussionRequest) (int, error) {
 	return result, nil
 }
 
-func GetDiscussion(repoId int64) (*DiscussionResponse, error) {
+func GetDiscussion(repoId int64) (*model.DiscussionResponse, error) {
 	resp, err := client.Request().
 		Get(fmt.Sprintf("/discussion/%d", repoId))
 	if err != nil {
@@ -269,7 +55,7 @@ func GetDiscussion(repoId int64) (*DiscussionResponse, error) {
 		return nil, err
 	}
 
-	var result DiscussionResponse
+	var result model.DiscussionResponse
 	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response body: %w", err)
 	}
@@ -277,7 +63,7 @@ func GetDiscussion(repoId int64) (*DiscussionResponse, error) {
 	return &result, nil
 }
 
-func GetDiscussionCount(repoId int64) (*DiscussionCountResponse, error) {
+func GetDiscussionCount(repoId int64) (*model.DiscussionCountResponse, error) {
 	resp, err := client.Request().
 		Get(fmt.Sprintf("/discussion/%d/count", repoId))
 	if err != nil {
@@ -288,7 +74,7 @@ func GetDiscussionCount(repoId int64) (*DiscussionCountResponse, error) {
 		return nil, err
 	}
 
-	var result DiscussionCountResponse
+	var result model.DiscussionCountResponse
 	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response body: %w", err)
 	}
@@ -296,7 +82,7 @@ func GetDiscussionCount(repoId int64) (*DiscussionCountResponse, error) {
 	return &result, nil
 }
 
-func GetDiscussionList(repoId int64, isClosed bool, page int, sort string) (*DiscussionListResponse, error) {
+func GetDiscussionList(repoId int64, isClosed bool, page int, sort string) (*model.DiscussionListResponse, error) {
 	isClosedAsString := strconv.FormatBool(isClosed)
 	pageAsString := strconv.Itoa(page)
 	resp, err := client.Request().
@@ -312,7 +98,7 @@ func GetDiscussionList(repoId int64, isClosed bool, page int, sort string) (*Dis
 		return nil, err
 	}
 
-	var result DiscussionListResponse
+	var result model.DiscussionListResponse
 	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response body: %w", err)
 	}
@@ -320,7 +106,7 @@ func GetDiscussionList(repoId int64, isClosed bool, page int, sort string) (*Dis
 	return &result, nil
 }
 
-func GetDiscussionContent(discussionId int64) (*DiscussionContentResponse, error) {
+func GetDiscussionContent(discussionId int64) (*model.DiscussionContentResponse, error) {
 	resp, err := client.Request().
 		Get(fmt.Sprintf("/discussion/%d/contents", discussionId))
 	if err != nil {
@@ -331,7 +117,7 @@ func GetDiscussionContent(discussionId int64) (*DiscussionContentResponse, error
 		return nil, err
 	}
 
-	var result DiscussionContentResponse
+	var result model.DiscussionContentResponse
 	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response body: %w", err)
 	}
@@ -339,7 +125,7 @@ func GetDiscussionContent(discussionId int64) (*DiscussionContentResponse, error
 	return &result, nil
 }
 
-func GetDiscussionComment(discussionCommentId int64) (*DiscussionCommentResponse, error) {
+func GetDiscussionComment(discussionCommentId int64) (*model.DiscussionCommentResponse, error) {
 
 	resp, err := client.Request().
 		SetQueryParam("id", strconv.FormatInt(discussionCommentId, 10)).
@@ -353,7 +139,7 @@ func GetDiscussionComment(discussionCommentId int64) (*DiscussionCommentResponse
 		return nil, err
 	}
 
-	var result DiscussionCommentResponse
+	var result model.DiscussionCommentResponse
 	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, fmt.Errorf("failed to parse response body: %w", err)
 	}
@@ -361,10 +147,10 @@ func GetDiscussionComment(discussionCommentId int64) (*DiscussionCommentResponse
 	return &result, nil
 }
 
-func GetDiscussionCommentsByCodeId(codeId int64) ([]*DiscussionCommentResponse, error) {
+func GetDiscussionCommentsByCodeId(codeId int64) ([]*model.DiscussionCommentResponse, error) {
 	resp, err := client.Request().Get(fmt.Sprintf("/discussion/comments/%d", codeId))
 
-	result := make([]*DiscussionCommentResponse, 0)
+	result := make([]*model.DiscussionCommentResponse, 0)
 
 	if err = json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
@@ -388,7 +174,7 @@ func HandleDiscussionAvailable() (*resty.Response, error) {
 	return resp, nil
 }
 
-func PostComment(request *PostCommentRequest) (*int64, error) {
+func PostComment(request *model.PostCommentRequest) (*int64, error) {
 	resp, err := client.Request().
 		SetBody(request).
 		Post("/discussion/comment")
@@ -409,7 +195,7 @@ func PostComment(request *PostCommentRequest) (*int64, error) {
 	return &id, nil
 }
 
-func ModifyDiscussion(request *ModifyDiscussionRequest) (*resty.Response, error) {
+func ModifyDiscussion(request *model.ModifyDiscussionRequest) (*resty.Response, error) {
 	resp, err := client.Request().
 		SetBody(request).
 		Put("/discussion")
@@ -425,7 +211,7 @@ func ModifyDiscussion(request *ModifyDiscussionRequest) (*resty.Response, error)
 }
 
 func DeleteDiscussionComment(discussionCommentId int64, posterId int64) error {
-	request := &DeleteDiscussionCommentRequest{
+	request := &model.DeleteDiscussionCommentRequest{
 		DiscussionCommentId: discussionCommentId,
 		PosterId:            posterId,
 	}
@@ -444,61 +230,12 @@ func DeleteDiscussionComment(discussionCommentId int64, posterId int64) error {
 	return nil
 }
 
-/**
- * discussion methods
- * the `discussion` struct could be moved to a separate file later
- */
-func (d *Discussion) IsExpired() bool {
-	return d.DeadlineUnix < timeutil.TimeStamp(time.Now().Unix())
-}
-
-func (d *Discussion) GetLastEventTimestamp() timeutil.TimeStamp {
-	if d.IsClosed {
-		return d.ClosedUnix
-	}
-	return d.CreatedUnix
-}
-
-func (d *Discussion) GetLastEventLabel() string {
-	if d.IsClosed {
-		return "repo.discussion.closed_by"
-	}
-	return "repo.discussion.opened_by"
-}
-
-func (d *Discussion) GetLastEventLabelFake() string {
-	if d.IsClosed {
-		return "repo.discussion.closed_by_fake"
-	}
-	return "repo.discussion.opened_by_fake"
-}
-
-func (d *Discussion) LoadPoster(ctx *context.Context) (err error) {
-	if d.Poster == nil && d.PosterId != 0 {
-		d.Poster, err = user_model.GetPossibleUserByID(ctx, d.PosterId)
-		if err != nil {
-			d.PosterId = user_model.GhostUserID
-			d.Poster = user_model.NewGhostUser()
-			if !user_model.IsErrUserNotExist(err) {
-				return fmt.Errorf("getUserById.(poster) [%d]: %w", d.PosterId, err)
-			}
-			return nil
-		}
-	}
-	return err
-}
-
-func (d *Discussion) LoadRepo(ctx *context.Context) (err error) {
-	d.Repo = ctx.Repo.Repository
-	return nil
-}
-
-func GetDiscussionContents(discussionId int64) (*DiscussionContentResponse, error) {
+func GetDiscussionContents(discussionId int64) (*model.DiscussionContentResponse, error) {
 	resp, err := client.Request().Get(fmt.Sprintf("/discussion/%d/contents", discussionId))
 	if err != nil {
 		return nil, err
 	}
-	result := &DiscussionContentResponse{}
+	result := &model.DiscussionContentResponse{}
 
 	if err := json.Unmarshal(resp.Body(), result); err != nil {
 		return nil, err
@@ -537,11 +274,7 @@ func SetDiscussionDeadline(discussionId int64, deadline int64) error {
 	return nil
 }
 
-func (dr DiscussionResponse) IsPoster(id int64) bool {
-	return dr.PosterId == id
-}
-
-func UpdateDiscussionAssignee(request *UpdateAssigneeRequest) error {
+func UpdateDiscussionAssignee(request *model.UpdateAssigneeRequest) error {
 	resp, err := client.Request().SetBody(request).Put("/discussion/assignees")
 	if err != nil {
 		return err
@@ -552,7 +285,7 @@ func UpdateDiscussionAssignee(request *UpdateAssigneeRequest) error {
 	return nil
 }
 
-func ModifyDiscussionComment(request *ModifyDiscussionCommentRequest) error {
+func ModifyDiscussionComment(request *model.ModifyDiscussionCommentRequest) error {
 	resp, err := client.Request().SetBody(request).Put("/discussion/comment")
 	if err != nil {
 		return err
@@ -576,7 +309,7 @@ func ClearDiscussionAssignee(discussionId int64) error {
 	return nil
 }
 
-func GiveReaction(request DiscussionReactionRequest) (int64, error) {
+func GiveReaction(request model.DiscussionReactionRequest) (int64, error) {
 	var result int64 = -1
 	resp, err := client.Request().SetBody(request).Post("/discussion/reaction")
 	if err != nil {
@@ -591,7 +324,7 @@ func GiveReaction(request DiscussionReactionRequest) (int64, error) {
 	return result, err
 }
 
-func RemoveReaction(request DiscussionReactionRequest) error {
+func RemoveReaction(request model.DiscussionReactionRequest) error {
 	resp, err := client.Request().SetBody(request).Delete("/discussion/reaction")
 	if err != nil {
 		return err

--- a/client/discussion/model/code_block.go
+++ b/client/discussion/model/code_block.go
@@ -1,0 +1,7 @@
+package model
+
+type CodeBlock struct {
+	CodeId   int64                       `json:"codeId"`
+	Lines    []ExtractedLine             `json:"lines"`
+	Comments []DiscussionCommentResponse `json:"comments"`
+}

--- a/client/discussion/model/comment_scope_enum.go
+++ b/client/discussion/model/comment_scope_enum.go
@@ -1,0 +1,8 @@
+package model
+
+type CommentScopeEnum int
+
+const (
+	CommentScopeGlobal CommentScopeEnum = iota
+	CommentScopeLocal
+)

--- a/client/discussion/model/delete_discussion_comment_request.go
+++ b/client/discussion/model/delete_discussion_comment_request.go
@@ -1,0 +1,6 @@
+package model
+
+type DeleteDiscussionCommentRequest struct {
+	PosterId            int64 `json:"posterId"`
+	DiscussionCommentId int64 `json:"discussionCommentId"`
+}

--- a/client/discussion/model/discussion.go
+++ b/client/discussion/model/discussion.go
@@ -1,0 +1,55 @@
+package model
+
+import (
+	"time"
+
+	repo_model "code.gitea.io/gitea/models/repo"
+	user_model "code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/timeutil"
+)
+
+type Discussion struct {
+	Id           int64                  `json:"id"`
+	Name         string                 `json:"name"`
+	Content      string                 `json:"content"`
+	RepoId       int64                  `json:"repoId"`
+	PosterId     int64                  `json:"posterId"`
+	CommitHash   string                 `json:"commitHash"`
+	Index        int64                  `json:"index"`
+	IsClosed     bool                   `json:"isClosed"`
+	CreatedUnix  timeutil.TimeStamp     `json:"createdUnix"` // required, but didn't exist before
+	ClosedUnix   timeutil.TimeStamp     `json:"closedUnix"`  // required, but didn't exist before
+	DeadlineUnix timeutil.TimeStamp     `json:"deadlineUnix"`
+	NumComments  int                    `json:"-"` // it can be computed
+	Repo         *repo_model.Repository `json:"-"` // it can be computed via d.LoadRepo()
+	Poster       *user_model.User       `json:"-"` // it can be computed via d.LoadPoster()
+}
+
+/**
+ * discussion methods
+ * the `discussion` struct could be moved to a separate file later
+ */
+func (d *Discussion) IsExpired() bool {
+	return d.DeadlineUnix < timeutil.TimeStamp(time.Now().Unix())
+}
+
+func (d *Discussion) GetLastEventTimestamp() timeutil.TimeStamp {
+	if d.IsClosed {
+		return d.ClosedUnix
+	}
+	return d.CreatedUnix
+}
+
+func (d *Discussion) GetLastEventLabel() string {
+	if d.IsClosed {
+		return "repo.discussion.closed_by"
+	}
+	return "repo.discussion.opened_by"
+}
+
+func (d *Discussion) GetLastEventLabelFake() string {
+	if d.IsClosed {
+		return "repo.discussion.closed_by_fake"
+	}
+	return "repo.discussion.opened_by_fake"
+}

--- a/client/discussion/model/discussion_available_request.go
+++ b/client/discussion/model/discussion_available_request.go
@@ -1,0 +1,6 @@
+package model
+
+type DiscussionAvailableRequest struct {
+	RepoId    int64 `json:"repoId"`
+	Available bool  `json:"available"`
+}

--- a/client/discussion/model/discussion_code.go
+++ b/client/discussion/model/discussion_code.go
@@ -1,0 +1,8 @@
+package model
+
+type DiscussionCode struct {
+	Id        int64  `json:"id"`
+	FilePath  string `json:"filePath"`
+	StartLine int    `json:"startLine"`
+	EndLine   int    `json:"endLine"`
+}

--- a/client/discussion/model/discussion_comment_response.go
+++ b/client/discussion/model/discussion_comment_response.go
@@ -1,0 +1,18 @@
+package model
+
+import "code.gitea.io/gitea/modules/timeutil"
+
+type DiscussionCommentResponse struct {
+	Id           int64                 `json:"id"`
+	FilePath     string                `json:"filePath"`
+	GroupId      int64                 `json:"groupId"`
+	DiscussionId int64                 `json:"discussionId"`
+	PosterId     int64                 `json:"posterId"`
+	CodeId       int64                 `json:"codeId"`
+	Scope        string                `json:"scope"`
+	StartLine    int64                 `json:"startLine"`
+	EndLine      int64                 `json:"endLine"`
+	Content      string                `json:"content"`
+	CreatedUnix  timeutil.TimeStamp    `json:"createdUnix"`
+	Reactions    []*DiscussionReaction `json:"reactions"`
+}

--- a/client/discussion/model/discussion_content_response.go
+++ b/client/discussion/model/discussion_content_response.go
@@ -1,0 +1,8 @@
+package model
+
+type DiscussionContentResponse struct {
+	DiscussionId    int64                       `json:"discussionId"`
+	Contents        []FileContent               `json:"contents"`
+	GlobalComments  []DiscussionCommentResponse `json:"globalComments"`
+	GlobalReactions []DiscussionReaction        `json:"discussionReaction"`
+}

--- a/client/discussion/model/discussion_count_respones.go
+++ b/client/discussion/model/discussion_count_respones.go
@@ -1,0 +1,6 @@
+package model
+
+type DiscussionCountResponse struct {
+	OpenCount  int `json:"openCount"`
+	CloseCount int `json:"closeCount"`
+}

--- a/client/discussion/model/discussion_deadline.go
+++ b/client/discussion/model/discussion_deadline.go
@@ -1,0 +1,7 @@
+package model
+
+import "time"
+
+type DiscussionDeadline struct {
+	Deadline *time.Time `json:"due_date"`
+}

--- a/client/discussion/model/discussion_error_response.go
+++ b/client/discussion/model/discussion_error_response.go
@@ -1,0 +1,10 @@
+package model
+
+import "code.gitea.io/gitea/modules/timeutil"
+
+type DiscussionErrorResponse struct {
+	TimeStamp timeutil.TimeStamp `json:"timestamp"`
+	Status    int                `json:"status"`
+	Error     string             `json:"error"`
+	Message   string
+}

--- a/client/discussion/model/discussion_list_response.go
+++ b/client/discussion/model/discussion_list_response.go
@@ -1,0 +1,6 @@
+package model
+
+type DiscussionListResponse struct {
+	TotalCount  int64         `json:"totalCount"`
+	Discussions []*Discussion `json:"discussions"`
+}

--- a/client/discussion/model/discussion_reaction.go
+++ b/client/discussion/model/discussion_reaction.go
@@ -1,0 +1,9 @@
+package model
+
+type DiscussionReaction struct {
+	Id           int64            `json:"id"`
+	Type         ReactionTypeEnum `json:"type"`
+	DiscussionId int64            `json:"discussionId"`
+	CommentId    int64            `json:"commentId"`
+	UserId       int64            `json:"userId"`
+}

--- a/client/discussion/model/discussion_reaction_list.go
+++ b/client/discussion/model/discussion_reaction_list.go
@@ -1,0 +1,23 @@
+package model
+
+type ReactionList []*DiscussionReaction
+
+func (list ReactionList) GroupByType() map[string]ReactionList {
+	reactions := make(map[string]ReactionList)
+	for _, reaction := range list {
+		reactions[reaction.Type] = append(reactions[reaction.Type], reaction)
+	}
+	return reactions
+}
+
+func (list ReactionList) HasUser(userId int64) bool {
+	if userId == 0 {
+		return false
+	}
+	for _, reaction := range list {
+		if reaction.UserId == userId {
+			return true
+		}
+	}
+	return false
+}

--- a/client/discussion/model/discussion_reaction_request.go
+++ b/client/discussion/model/discussion_reaction_request.go
@@ -1,0 +1,8 @@
+package model
+
+type DiscussionReactionRequest struct {
+	Type         ReactionTypeEnum `json:"type"`
+	DiscussionId int64            `json:"discussionId"`
+	CommentId    int64            `json:"commentId"`
+	UserId       int64            `json:"userId"`
+}

--- a/client/discussion/model/discussion_response.go
+++ b/client/discussion/model/discussion_response.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"code.gitea.io/gitea/models/user"
+	"code.gitea.io/gitea/modules/timeutil"
+)
+
+type DiscussionResponse struct {
+	Id          int64              `json:"id"`
+	Name        string             `json:"name"`
+	Content     string             `json:"content"`
+	RepoId      int64              `json:"repoId"`
+	PosterId    int64              `json:"posterId"`
+	CommitHash  string             `json:"commitHash"`
+	IsClosed    bool               `json:"isClosed"`
+	Deadline    timeutil.TimeStamp `json:"deadline"`
+	Assignees   []int64            `json:"assignees"`
+	CreatedUnix timeutil.TimeStamp `json:"createdUnix"`
+	UpdatedUnix timeutil.TimeStamp `json:"updatedUnix"`
+	Index       int64              `json:"index"`
+	Poster      *user.User         `json:"-"`
+}
+
+func (dr DiscussionResponse) IsPoster(id int64) bool {
+	return dr.PosterId == id
+}

--- a/client/discussion/model/extracted_line.go
+++ b/client/discussion/model/extracted_line.go
@@ -1,0 +1,6 @@
+package model
+
+type ExtractedLine struct {
+	LineNumber int    `json:"lineNumber"`
+	Content    string `json:"content"`
+}

--- a/client/discussion/model/file_content.go
+++ b/client/discussion/model/file_content.go
@@ -1,0 +1,6 @@
+package model
+
+type FileContent struct {
+	FilePath   string      `json:"filePath"`
+	CodeBlocks []CodeBlock `json:"codeBlocks"`
+}

--- a/client/discussion/model/modify_discussion_comment_request.go
+++ b/client/discussion/model/modify_discussion_comment_request.go
@@ -1,0 +1,12 @@
+package model
+
+type ModifyDiscussionCommentRequest struct {
+	DiscussionId        int64            `json:"discussionId"`
+	DiscussionCommentId int64            `json:"discussionCommentId"`
+	CodeId              *int64           `json:"codeId"`
+	PosterId            int64            `json:"posterId"`
+	Scope               CommentScopeEnum `json:"scope"`
+	StartLine           *int32           `json:"startLine"`
+	EndLine             *int32           `json:"endLine"`
+	Content             string           `json:"content"`
+}

--- a/client/discussion/model/modify_discussion_request.go
+++ b/client/discussion/model/modify_discussion_request.go
@@ -1,0 +1,10 @@
+package model
+
+type ModifyDiscussionRequest struct {
+	RepoId       int64            `json:"repoId"`
+	DiscussionId int64            `json:"discussionId"`
+	PosterId     int64            `json:"posterId"`
+	Name         string           `json:"name"`
+	Content      string           `json:"content"`
+	Codes        []DiscussionCode `json:"codes"`
+}

--- a/client/discussion/model/post_comment_request.go
+++ b/client/discussion/model/post_comment_request.go
@@ -1,0 +1,12 @@
+package model
+
+type PostCommentRequest struct {
+	DiscussionId int64            `json:"discussionId"`
+	CodeId       *int64           `json:"codeId"`
+	GroupId      *int64           `json:"groupId"`
+	PosterId     int64            `json:"posterId"`
+	Scope        CommentScopeEnum `json:"scope"`
+	StartLine    *int32           `json:"startLine"`
+	EndLine      *int32           `json:"endLine"`
+	Content      string           `json:"content"`
+}

--- a/client/discussion/model/post_discussion_request.go
+++ b/client/discussion/model/post_discussion_request.go
@@ -1,0 +1,13 @@
+package model
+
+import user_model "code.gitea.io/gitea/models/user"
+
+type PostDiscussionRequest struct {
+	RepoId     int64            `json:"repoId"`
+	Poster     *user_model.User `json:"-"`
+	PosterId   int64            `json:"posterId"`
+	Name       string           `json:"name"`
+	Content    string           `json:"content"`
+	BranchName string           `json:"branchName"`
+	Codes      []DiscussionCode `json:"codes"`
+}

--- a/client/discussion/model/reaction_type_enum.go
+++ b/client/discussion/model/reaction_type_enum.go
@@ -1,0 +1,14 @@
+package model
+
+type ReactionTypeEnum = string
+
+const (
+	PLUS_ONE  ReactionTypeEnum = "+1"
+	MINUS_ONE ReactionTypeEnum = "-1"
+	LAUGH     ReactionTypeEnum = "laugh"
+	HOORAY    ReactionTypeEnum = "hooray"
+	CONFUSED  ReactionTypeEnum = "confused"
+	HEART     ReactionTypeEnum = "heart"
+	ROCKET    ReactionTypeEnum = "rocket"
+	EYES      ReactionTypeEnum = "eyes"
+)

--- a/client/discussion/model/update_assignee_request.go
+++ b/client/discussion/model/update_assignee_request.go
@@ -1,0 +1,6 @@
+package model
+
+type UpdateAssigneeRequest struct {
+	DiscussionId int64 `json:"discussionId"`
+	AssigneeId   int64 `json:"assigneeId"`
+}

--- a/models/activities/notification.go
+++ b/models/activities/notification.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strconv"
 
+	"code.gitea.io/gitea/client/discussion/model"
 	"code.gitea.io/gitea/models/db"
 	issues_model "code.gitea.io/gitea/models/issues"
 	"code.gitea.io/gitea/models/organization"
@@ -45,6 +46,8 @@ const (
 	NotificationSourceCommit
 	// NotificationSourceRepository is a notification for a repository
 	NotificationSourceRepository
+	// NotificationSourceDiscussion is a notification for a discussion
+	NotificationSourceDiscussion
 )
 
 // Notification represents a notification
@@ -56,16 +59,18 @@ type Notification struct {
 	Status NotificationStatus `xorm:"SMALLINT INDEX NOT NULL"`
 	Source NotificationSource `xorm:"SMALLINT INDEX NOT NULL"`
 
-	IssueID   int64  `xorm:"INDEX NOT NULL"`
-	CommitID  string `xorm:"INDEX"`
-	CommentID int64
+	IssueID      int64  `xorm:"INDEX NOT NULL"`
+	DiscussionID int64  `xorm:"INDEX NOT NULL"`
+	CommitID     string `xorm:"INDEX"`
+	CommentID    int64
 
 	UpdatedBy int64 `xorm:"INDEX NOT NULL"`
 
-	Issue      *issues_model.Issue    `xorm:"-"`
-	Repository *repo_model.Repository `xorm:"-"`
-	Comment    *issues_model.Comment  `xorm:"-"`
-	User       *user_model.User       `xorm:"-"`
+	Issue      *issues_model.Issue       `xorm:"-"`
+	Repository *repo_model.Repository    `xorm:"-"`
+	Comment    *issues_model.Comment     `xorm:"-"`
+	User       *user_model.User          `xorm:"-"`
+	Discussion *model.DiscussionResponse `xorm:"-"`
 
 	CreatedUnix timeutil.TimeStamp `xorm:"created INDEX NOT NULL"`
 	UpdatedUnix timeutil.TimeStamp `xorm:"updated INDEX NOT NULL"`
@@ -155,6 +160,16 @@ func GetIssueNotification(ctx context.Context, userID, issueID int64) (*Notifica
 	_, err := db.GetEngine(ctx).
 		Where("user_id = ?", userID).
 		And("issue_id = ?", issueID).
+		Get(notification)
+	return notification, err
+}
+
+// GetDiscussionNotification return the notification about an issue
+func GetDiscussionNotification(ctx context.Context, userID, discussionID int64) (*Notification, error) {
+	notification := new(Notification)
+	_, err := db.GetEngine(ctx).
+		Where("user_id = ?", userID).
+		And("discussion_id = ?", discussionID).
 		Get(notification)
 	return notification, err
 }
@@ -373,5 +388,50 @@ func UpdateNotificationStatuses(ctx context.Context, user *user_model.User, curr
 		Where("user_id = ? AND status = ?", user.ID, currentStatus).
 		Cols("status", "updated_by", "updated_unix").
 		Update(n)
+	return err
+}
+
+func createDiscussionNotification(ctx context.Context, userID int64, discussionResp *model.DiscussionResponse, commentID, updatedByID int64) error {
+	notification := &Notification{
+		UserID:       userID,
+		RepoID:       discussionResp.RepoId,
+		Status:       NotificationStatusUnread,
+		IssueID:      0,
+		DiscussionID: discussionResp.Id,
+		CommentID:    commentID,
+		UpdatedBy:    updatedByID,
+		Source:       NotificationSourceDiscussion,
+	}
+	return db.Insert(ctx, notification)
+}
+
+func DiscussionNotificationExists(notifications []*Notification, discussionId, userId int64) bool {
+	for _, notification := range notifications {
+		if notification.DiscussionID == discussionId && notification.UserID == userId {
+			return true
+		}
+	}
+	return false
+}
+
+func updateDiscussionNotification(ctx context.Context, userID, discussionID, commentID, updatedByID int64) error {
+	notification, err := GetDiscussionNotification(ctx, userID, discussionID)
+	if err != nil {
+		return err
+	}
+
+	// NOTICE: Only update comment id when the before notification on this issue is read, otherwise you may miss some old comments.
+	// But we need update update_by so that the notification will be reorder
+	var cols []string
+	if notification.Status == NotificationStatusRead {
+		notification.Status = NotificationStatusUnread
+		notification.CommentID = commentID
+		cols = []string{"status", "update_by", "comment_id"}
+	} else {
+		notification.UpdatedBy = updatedByID
+		cols = []string{"update_by"}
+	}
+
+	_, err = db.GetEngine(ctx).ID(notification.ID).Cols(cols...).Update(notification)
 	return err
 }

--- a/modules/structs/hook.go
+++ b/modules/structs/hook.go
@@ -365,6 +365,22 @@ func (p *IssuePayload) JSONPayload() ([]byte, error) {
 	return json.MarshalIndent(p, "", "  ")
 }
 
+type DiscussionPayload struct {
+	Repository *Repository `json:"repository"`
+	Sender     *User       `json:"sender"`
+
+	// FIXME: For now because of cyclic reference, I separated each required fields one by one
+	// But after refactoring this field must be abstracted by one Discussion struct
+	DiscussionIndex           int64  `json:"discussion_index"`
+	DiscussionTitle           string `json:"discussion_title"`
+	DiscussionCreateTimestamp int64  `json:"discussion_create_timestamp"`
+	DiscussionLink            string `json:"discussion_link"`
+}
+
+func (p *DiscussionPayload) JSONPayload() ([]byte, error) {
+	return json.MarshalIndent(p, "", " ")
+}
+
 // ChangesFromPayload FIXME
 type ChangesFromPayload struct {
 	From string `json:"from"`

--- a/modules/webhook/type.go
+++ b/modules/webhook/type.go
@@ -32,6 +32,7 @@ const (
 	HookEventRelease                   HookEventType = "release"
 	HookEventPackage                   HookEventType = "package"
 	HookEventSchedule                  HookEventType = "schedule"
+	HookEventDiscussions               HookEventType = "discussions"
 )
 
 // Event returns the HookEventType as an event string

--- a/routers/web/user/notification.go
+++ b/routers/web/user/notification.go
@@ -150,6 +150,10 @@ func getNotifications(ctx *context.Context) {
 		return
 	}
 
+	// FIXME: current LoadDiscussion does not fit with legacy implemenations..
+	// later it must be fitted with other Loadxxx
+	notifications.LoadDiscussion(ctx)
+
 	notifications = notifications.Without(failures)
 	failCount += len(failures)
 

--- a/services/forms/repo_discussion_form.go
+++ b/services/forms/repo_discussion_form.go
@@ -3,7 +3,7 @@ package forms
 import (
 	"net/http"
 
-	discussion_client "code.gitea.io/gitea/client/discussion"
+	"code.gitea.io/gitea/client/discussion/model"
 	"code.gitea.io/gitea/modules/web/middleware"
 	"code.gitea.io/gitea/services/context"
 	"gitea.com/go-chi/binding"
@@ -13,7 +13,7 @@ type CreateDiscussionForm struct {
 	Name       string
 	Content    string
 	BranchName string
-	Codes      []discussion_client.DiscussionCode
+	Codes      []model.DiscussionCode
 }
 
 func (d *CreateDiscussionForm) Validate(req *http.Request, errs binding.Errors) binding.Errors {

--- a/services/notify/notifier.go
+++ b/services/notify/notifier.go
@@ -74,4 +74,6 @@ type Notifier interface {
 	PackageDelete(ctx context.Context, doer *user_model.User, pd *packages_model.PackageDescriptor)
 
 	ChangeDefaultBranch(ctx context.Context, repo *repo_model.Repository)
+
+	NewDiscussion(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, discussionId int)
 }

--- a/services/notify/notify.go
+++ b/services/notify/notify.go
@@ -367,3 +367,10 @@ func ChangeDefaultBranch(ctx context.Context, repo *repo_model.Repository) {
 		notifier.ChangeDefaultBranch(ctx, repo)
 	}
 }
+
+func NewDiscussion(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, discussionId int) {
+	for _, notifier := range notifiers {
+		log.Info("iterating notifiers on NewDiscussion... ")
+		notifier.NewDiscussion(ctx, doer, repo, discussionId)
+	}
+}

--- a/services/notify/notify.go
+++ b/services/notify/notify.go
@@ -370,7 +370,6 @@ func ChangeDefaultBranch(ctx context.Context, repo *repo_model.Repository) {
 
 func NewDiscussion(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, discussionId int) {
 	for _, notifier := range notifiers {
-		log.Info("iterating notifiers on NewDiscussion... ")
 		notifier.NewDiscussion(ctx, doer, repo, discussionId)
 	}
 }

--- a/services/notify/null.go
+++ b/services/notify/null.go
@@ -208,3 +208,7 @@ func (*NullNotifier) PackageDelete(ctx context.Context, doer *user_model.User, p
 // ChangeDefaultBranch places a place holder function
 func (*NullNotifier) ChangeDefaultBranch(ctx context.Context, repo *repo_model.Repository) {
 }
+
+// NewDiscussion places a place holder function
+func (*NullNotifier) NewDiscussion(ctx context.Context, doer *user_model.User, repo *repo_model.Repository, discussionId int) {
+}

--- a/templates/user/notification/notification_div.tmpl
+++ b/templates/user/notification/notification_div.tmpl
@@ -35,6 +35,7 @@
 					</div>
 				{{else}}
 					{{range $notification := .Notifications}}
+						{{if ne .IssueID 0}}
 						<div class="notifications-item tw-flex tw-items-center tw-flex-wrap tw-gap-2 tw-p-2" id="notification_{{.ID}}" data-status="{{.Status}}">
 							<div class="notifications-icon tw-ml-2 tw-mr-1 tw-self-start tw-mt-1">
 								{{if .Issue}}
@@ -116,6 +117,37 @@
 								{{end}}
 							</div>
 						</div>
+						{{else if ne .DiscussionID 0}}
+						<div class="notifications-item tw-flex tw-items-center tw-flex-wrap tw-gap-2 tw-p-2" id="notification_{{.ID}}" data-status="{{.Status}}">
+							<div class="notifications-icon tw-ml-2 tw-mr-1 tw-self-start tw-mt-1">
+								{{svg "octicon-comment-discussion" 16 "text grey"}}
+							</div>
+							<a class="notifications-link tw-flex tw-flex-1 tw-flex-col silenced" href="/{{.Repository.FullName}}/discussions/{{.Discussion.Id}}">
+								<div class="notifications-top-row tw-text-13">
+									{{.Repository.FullName}}
+									<span class="text light-3">#{{.Discussion.Index}}</span>
+									{{if eq .Status 3}}
+										{{svg "octicon-pin" 13 "text blue tw-mt-0.5 tw-ml-1"}}
+									{{end}}
+								</div>
+								<div class="notifications-bottom-row tw-text-15 tw-py-0.5">
+									<span class="issue-title">
+										{{.Discussion.Name | RenderEmoji $.Context | RenderCodeBlock}}
+									</span>
+								</div>
+							</a>
+							<div class="notifications-updated tw-items-center tw-mr-2">
+								{{TimeSinceUnix .Discussion.UpdatedUnix ctx.Locale}}
+							</div>
+							
+							<!-- 
+							TODO: handle mouse over
+							<div class="notifications-buttons tw-items-center tw-justify-end tw-gap-1 tw-px-1">
+							
+							</div> 
+							-->
+						</div>
+						{{end}}
 					{{end}}
 				{{end}}
 			</div>


### PR DESCRIPTION
아직 진행중이고 핵심 기능인 알림 기능들은 모두 로컬에서 작업진행중입니다. 
그럼에도 미리 PR을 올리는 이유는 순환 참조를 해결하다가 과도하게 커져 버린 client 가 문제라는 것을 파악했고, 추후 머지할때 일어날 큰 충돌이 두려워서 일단 올립니다. 필요하시면 체리픽으로 커밋만 미리 쏙쏙빼다 박는것으로 큰 충돌은 예방할수 있어보이네요. 감사합니다

추가로 
`ae3f704`는 client 에 있는 모든 struct 및 type을 하위 model 패키지로 이동한 커밋이고
`5b68d25`는 앞서 말한 PR 적용시 일어나는 문제 해결 및, 순환 참조 문제를 해결한 커밋입니다.
필요에 따라 체리픽으로 가져다 쓰세요