### PR TITLE
기존 CodeLineSelector 에서 문서의 타이틀바가 계속 보이는 문제 해결

### DIFF
--- a/web_src/js/components/DiscussionCodeLineSelector.vue
+++ b/web_src/js/components/DiscussionCodeLineSelector.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="file-header ui top attached header tw-items-center tw-justify-between tw-flex-wrap"
-    style="position: sticky; top: 0; z-index: 999"
+    style="position: sticky; top: 0; z-index: 10"
   >
     <div class="file-info tw-font-mono">
       <div :id="`discussion-${content.NameHash}`" class="file-info-entry">


### PR DESCRIPTION
z-index 수정을 통해 해결했습니다