### PR TITLE
DiscussionTree 에서 문법 에러 수정  + 추가 기능

### DIFF
--- a/templates/repo/discussion/new_form.tmpl
+++ b/templates/repo/discussion/new_form.tmpl
@@ -3,7 +3,7 @@
 {{end}}
 <form id="new-discussion" action="{{.Link}}" method="post">
 	{{.CsrfTokenHtml}}
-	<div id="discussion-form" style="display: flex; width: 100%; "></div>
+	<div id="discussion-form"  class="tw-flex tw-w-full tw-overflow-x-clip" ></div>
 	<script>
 		window.config.pageData.repoLink = "{{.RepoLink}}";
 	</script>

--- a/web_src/js/components/DiscussionForm.vue
+++ b/web_src/js/components/DiscussionForm.vue
@@ -289,7 +289,7 @@ export default {
     :style="[
         collapseMenu 
             ? 'position: absolute; right: 0; height: 100px; '
-            : 'padding: 12px; max-height: 24px; margin-left: 18px; max-height: 990px; border: 1px solid #d0d7de; border-radius: 4px; '
+            : 'padding: 16px; max-height: 24px; margin-left: 18px; max-height: 990px; border: 1px solid #d0d7de; border-radius: 4px; '
     ]">
     <div aria-label="collapsable-menu" class="tw-flex tw-align-center tw-justify-end">
         <button @click.prevent="collapseMenu=!collapseMenu" class="tw-p-2" :style="[

--- a/web_src/js/components/DiscussionForm.vue
+++ b/web_src/js/components/DiscussionForm.vue
@@ -21,6 +21,7 @@ export default {
         dragStart: undefined, 
         dragLast: undefined, 
         dragEnd: undefined, 
+        collapseMenu: false, 
     }),
     async mounted() {
         await this.fetchBranches();
@@ -283,44 +284,63 @@ export default {
     </div>
 </div>
 
-<div class="discussion-content-right" style="flex-shrink: 0; width: 320px; margin-left: 18px; border: 1px solid #d0d7de; border-radius: 4px; padding: 16px; max-height: 990px; overflow: auto;">
-    <span class="text muted flex-text-block" style="margin-bottom: 12px;">
-        <strong>브랜치 선택</strong>
-    </span>
+<div class="discussion-content-right" 
+    style="overflow: auto; flex-shrink: 0; max-width: 320px;"
+    :style="[
+        collapseMenu 
+            ? 'position: absolute; right: 0; height: 100px; '
+            : 'padding: 12px; max-height: 24px; margin-left: 18px; max-height: 990px; border: 1px solid #d0d7de; border-radius: 4px; '
+    ]">
+    <div aria-label="collapsable-menu" class="tw-flex tw-align-center tw-justify-end">
+        <button @click.prevent="collapseMenu=!collapseMenu" class="tw-p-2" :style="[
+            collapseMenu
+                ? 'background: #f1f3f5; border-radius: 12px 0 0 12px; height: 100px; width: 24px; border: 1px solid #d0d7de;'
+                : 'background: transparent;'
+        ]">
+            <SvgIcon :name="collapseMenu ? 'octicon-chevron-left' : 'octicon-x'"></SvgIcon>
+        </button>
+    </div>
 
-    <select class="tw-w-full" style="background-color: #f8f9fb; padding: 12px; border-radius: 6px; border: 1px solid #dcdde1;" v-model="selectedBranch" >
-        <option disabled value="null">브랜치를 선택해주세요</option>
-        <option :value="b" v-for="b in branches">{{b}}</option>
-    </select>
 
+    <div class="asdf" v-show="!collapseMenu">
+        <span class="text muted flex-text-block" style="margin-bottom: 12px;">
+            <SvgIcon name="octicon-git-branch"></SvgIcon>
+            <strong>선택된 브랜치</strong>
+        </span>
 
-    <div class="divider"></div>
+        <select class="tw-w-full" style="background-color: #f8f9fb; padding: 8px 12px;  border-radius: 6px; border: 1px solid #dcdde1;" v-model="selectedBranch" >
+            <option disabled value="null">브랜치를 선택해주세요</option>
+            <option :value="b" v-for="b in branches">{{b}}</option>
+        </select>
+        <div class="divider"></div>
 
-    <span class="text muted flex-text-block" style="margin-bottom: 12px;">
-        <strong>선택된 파일 목록</strong>
-    </span>
+        <span class="text muted flex-text-block" style="margin-bottom: 12px;">
+            <SvgIcon name="octicon-file"></SvgIcon>
+            <strong>선택된 파일 목록</strong>
+        </span>
 
-    <span style="color: grey;" v-if="store.checkedItems.length === 0">
-        선택된 항목이 존재하지 않습니다.
-    </span>
-    <div v-else>
-        <div v-for="item in store.checkedItems" 
-            class="checked-item"
-            :data-checked-item-tag="item.tag"
-            :data-checked-item-file="item.file"
-            :data-checked-item-start="item.start"
-            :data-checked-item-end="item.end"
-            @click="handleGotoCheckedFileRange"
-            style="border: 1px solid #dcdde1; padding: 6px; margin: 3px; border-radius: 5px; cursor: pointer;">
+        <span style="color: grey;" v-if="store.checkedItems.length === 0">
+            선택된 항목이 존재하지 않습니다.
+        </span>
+        <div v-else>
+            <div v-for="item in store.checkedItems" 
+                class="checked-item"
+                :data-checked-item-tag="item.tag"
+                :data-checked-item-file="item.file"
+                :data-checked-item-start="item.start"
+                :data-checked-item-end="item.end"
+                @click="handleGotoCheckedFileRange"
+                style="border: 1px solid #dcdde1; padding: 6px; margin: 3px; border-radius: 5px; cursor: pointer;">
 
-            <span style="display: flex; justify-content: space-between;">
-                <div>
-                    <SvgIcon name="octicon-file"/>{{ item.file }}:{{ item.start }}-{{  item.end }}
-                </div>
-                <div>
-                    <SvgIcon name="octicon-x" @click.prevent.stop="handleRemoveCheckedItem"/>
-                </div>  
-            </span>
+                <span style="display: flex; justify-content: space-between;">
+                    <div>
+                        <SvgIcon name="octicon-file"/>{{ item.file }}:{{ item.start }}-{{  item.end }}
+                    </div>
+                    <div>
+                        <SvgIcon name="octicon-x" @click.prevent.stop="handleRemoveCheckedItem"/>
+                    </div>  
+                </span>
+            </div>
         </div>
     </div>
 </div>

--- a/web_src/js/components/DiscussionForm.vue
+++ b/web_src/js/components/DiscussionForm.vue
@@ -38,8 +38,15 @@ export default {
             inputStyle: 'contenteditable',
             nativeSpellCheck: true, 
         });
+        window.addEventListener('resize', this.handleResize); 
     },
+    beforeDestroy() {
+        window.removeEventListener('resize', this.handleResize);
+    }, 
     methods: {
+        handleResize() {
+            if (window.innerWidth < 1060) this.collapseMenu = true; 
+        }, 
         async fetchBranches() {
             const resp = await GET(`${this.store.repoLink}/branches/list`);
             const { results } = await resp.json(); 

--- a/web_src/js/components/DiscussionForm.vue
+++ b/web_src/js/components/DiscussionForm.vue
@@ -244,20 +244,7 @@ export default {
                                             </td>
                                             <td class="lines-code chroma" v-html="content.content"/>
                                             <button @click.stop.prevent="handleAddDiscussionCode"
-                                                    class="discussion-add-button"
-                                                    style="
-                                                        position: absolute; 
-                                                        cursor: pointer;
-                                                        color: black; 
-                                                        background-color: #f1f3f5;
-                                                        top: 16px;
-                                                        right: 4px;
-                                                        padding: 8px;
-                                                        z-index: 1;
-                                                        border-radius: 6px;
-                                                        border: 1px solid grey;
-                                                        justify-content: center;
-                                                        font-size: smaller;">
+                                                    class="discussion-add-button ui primary button tw-absolute tw-right-0 tw-bottom-0 tw-text-xs tw-opacity-50 hover:tw-opacity-100 tw-p-2">
                                                 <span>선택 영역 추가하기</span>
                                             </button>
                                         </tr>
@@ -322,7 +309,7 @@ export default {
     </div>
 
 
-    <div class="asdf" v-show="!collapseMenu">
+    <div v-show="!collapseMenu">
         <span class="text muted flex-text-block" style="margin-bottom: 12px;">
             <SvgIcon name="octicon-git-branch"></SvgIcon>
             <strong>선택된 브랜치</strong>

--- a/web_src/js/components/DiscussionTree.vue
+++ b/web_src/js/components/DiscussionTree.vue
@@ -107,7 +107,7 @@ export default {
   watch: {
     localSearchInput: debounce(function (value) {
       this.store.searchInput = value; 
-    }, 33);
+    }, 33),
   }
 };
 </script>

--- a/web_src/js/components/DiscussionTree.vue
+++ b/web_src/js/components/DiscussionTree.vue
@@ -134,6 +134,9 @@ export default {
   width: 100%; 
   padding: 5px; 
   margin-bottom: 6px; 
+
+  position: sticky;
+  top: 0;
 }
 
 .search-input::placeholder {


### PR DESCRIPTION
- 문법 에러 수정 
- 검색 상자 `position: sticky`
<img width="347" alt="image" src="https://github.com/user-attachments/assets/6fc2009b-d93b-4f0c-8cab-55ca7a667a85">

- 디스커션 생성 우측 메뉴 토글 
  -  닫기 버튼 (tab 으로 focus 된 상태, border 없음) 
  <img width="347" alt="Screenshot 2024-11-12 at 1 19 50 AM" src="https://github.com/user-attachments/assets/ab139698-ee24-4c2b-8a16-80c1374373cf">  

  -  닫힌 모습
  <img width="315" alt="Screenshot 2024-11-12 at 1 20 03 AM" src="https://github.com/user-attachments/assets/b655cf67-0b72-4ea0-ba72-32997289dbda">

- 디스커션 작성 프리뷰 
  <img width="1290" alt="Screenshot 2024-11-12 at 1 22 24 AM" src="https://github.com/user-attachments/assets/1f1babe8-8eaa-47b1-9943-82d7729ca7cc">


기타 이용자 편의를 위한 여러 사소한 부분의 UI 수정이 존재합니다
